### PR TITLE
Add support for multi-character ValueSeparators

### DIFF
--- a/Cesil.Benchmark/Benchmarks/Internals/NeedsEncodeBenchmark.cs
+++ b/Cesil.Benchmark/Benchmarks/Internals/NeedsEncodeBenchmark.cs
@@ -18,7 +18,7 @@ namespace Cesil.Benchmark
 
         private List<string> Strings;
 
-        private char BasicContains_C1;
+        private string BasicContains_C1;
         private char? BasicContains_C2;
         private char? BasicContains_C3;
 
@@ -40,7 +40,7 @@ namespace Cesil.Benchmark
 
             Strings = strRet;
 
-            BasicContains_C1 = ',';
+            BasicContains_C1 = ",";
             BasicContains_C2 = '"';
             BasicContains_C3 = null;
 

--- a/Cesil.Tests/BufferWithPushbackTests.cs
+++ b/Cesil.Tests/BufferWithPushbackTests.cs
@@ -23,7 +23,7 @@ namespace Cesil.Tests
                         MemoryPool<char>.Shared,
                         500
                     );
-                var bytes = buf.Read(new TextReaderAdapter(str));
+                var bytes = buf.Read(new TextReaderAdapter(str), true);
                 Assert.Equal(TEXT.Length, bytes);
 
                 var shouldMatch = new string(buf.Buffer.Span.Slice(0, bytes));
@@ -50,7 +50,7 @@ namespace Cesil.Tests
                                 MemoryPool<char>.Shared,
                                 500
                             );
-                        var bytes = await buf.ReadAsync(str, CancellationToken.None);
+                        var bytes = await buf.ReadAsync(str, true, CancellationToken.None);
                         Assert.Equal(TEXT.Length, bytes);
 
                         var shouldMatch = new string(buf.Buffer.Span.Slice(0, bytes));
@@ -76,7 +76,7 @@ namespace Cesil.Tests
                         MemoryPool<char>.Shared,
                         500
                     );
-                var bytes = buf.Read(new TextReaderAdapter(str));
+                var bytes = buf.Read(new TextReaderAdapter(str), true);
                 Assert.Equal(TEXT.Length, bytes);
 
                 var shouldMatch = new string(buf.Buffer.Span.Slice(0, bytes));
@@ -84,7 +84,7 @@ namespace Cesil.Tests
 
                 buf.PushBackFromBuffer(bytes, SECOND_TEXT.Length);
 
-                var bytes2 = buf.Read(new TextReaderAdapter(str));
+                var bytes2 = buf.Read(new TextReaderAdapter(str), true);
 
                 Assert.Equal(SECOND_TEXT.Length, bytes2);
 
@@ -111,7 +111,7 @@ namespace Cesil.Tests
                                 MemoryPool<char>.Shared,
                                 500
                             );
-                        var bytes = await buf.ReadAsync(str, CancellationToken.None);
+                        var bytes = await buf.ReadAsync(str, true, CancellationToken.None);
                         Assert.Equal(TEXT.Length, bytes);
 
                         var shouldMatch = new string(buf.Buffer.Span.Slice(0, bytes));
@@ -119,7 +119,7 @@ namespace Cesil.Tests
 
                         buf.PushBackFromBuffer(bytes, SECOND_TEXT.Length);
 
-                        var bytes2 = await buf.ReadAsync(str, CancellationToken.None);
+                        var bytes2 = await buf.ReadAsync(str, true, CancellationToken.None);
 
                         Assert.Equal(SECOND_TEXT.Length, bytes2);
 

--- a/Cesil.Tests/ConfigurationTests.cs
+++ b/Cesil.Tests/ConfigurationTests.cs
@@ -457,6 +457,12 @@ namespace Cesil.Tests
         [Fact]
         public void OptionsValidation()
         {
+            Assert.Throws<ArgumentNullException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(null));
+            Assert.Throws<ArgumentException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(""));
+
+            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparatorInternal(null).ToOptions());
+            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparatorInternal("").ToOptions());
+
             Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(','.ToString()).WithEscapedValueStartAndEnd(',').ToOptions());
 
             Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(','.ToString()).WithCommentCharacter(',').ToOptions());

--- a/Cesil.Tests/ConfigurationTests.cs
+++ b/Cesil.Tests/ConfigurationTests.cs
@@ -181,7 +181,7 @@ namespace Cesil.Tests
             var cOpts =
                 Options.CreateBuilder(Options.Default)
                     .WithEscapedValueStartAndEnd(char.MinValue)
-                    .WithValueSeparator(char.MaxValue)
+                    .WithValueSeparator(char.MaxValue.ToString())
                     .WithEscapedValueEscapeCharacter('c')
                     .WithCommentCharacter('d')
                     .ToOptions();
@@ -189,7 +189,7 @@ namespace Cesil.Tests
             var dOpts =
                 Options.CreateBuilder(Options.Default)
                     .WithEscapedValueStartAndEnd('"')
-                    .WithValueSeparator(',')
+                    .WithValueSeparator(','.ToString())
                     .WithEscapedValueEscapeCharacter('"')
                     .WithCommentCharacter('#')
                     .ToOptions();
@@ -294,7 +294,7 @@ namespace Cesil.Tests
                                                                             .WithReadHeader(rh)
                                                                             .WithRowEnding(re)
                                                                             .WithTypeDescriber(typeDesc)
-                                                                            .WithValueSeparator(valSepChar)
+                                                                            .WithValueSeparator(valSepChar.ToString())
                                                                             .WithWriteBufferSizeHint(writeHint)
                                                                             .WithWriteHeader(wh)
                                                                             .WithWriteTrailingRowEnding(wt)
@@ -457,9 +457,9 @@ namespace Cesil.Tests
         [Fact]
         public void OptionsValidation()
         {
-            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(',').WithEscapedValueStartAndEnd(',').ToOptions());
+            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(','.ToString()).WithEscapedValueStartAndEnd(',').ToOptions());
 
-            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(',').WithCommentCharacter(',').ToOptions());
+            Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithValueSeparator(','.ToString()).WithCommentCharacter(',').ToOptions());
 
             Assert.Throws<InvalidOperationException>(() => Options.CreateBuilder(Options.Default).WithEscapedValueStartAndEnd(',').WithCommentCharacter(',').ToOptions());
 
@@ -474,7 +474,7 @@ namespace Cesil.Tests
 
             Assert.Throws<InvalidOperationException>(
                 () =>
-                    Options.CreateBuilder().WithValueSeparator(',')
+                    Options.CreateBuilder().WithValueSeparator(','.ToString())
                     .WithRowEnding(RowEnding.CarriageReturnLineFeed)
                     .WithEscapedValueStartAndEnd('"')
                     .WithEscapedValueEscapeCharacter('"')
@@ -494,7 +494,7 @@ namespace Cesil.Tests
 
             Assert.Throws<InvalidOperationException>(
                 () =>
-                    Options.CreateBuilder().WithValueSeparator(',')
+                    Options.CreateBuilder().WithValueSeparator(','.ToString())
                     .WithRowEnding(RowEnding.CarriageReturnLineFeed)
                     .WithEscapedValueStartAndEnd('"')
                     .WithEscapedValueEscapeCharacter('"')
@@ -569,7 +569,7 @@ namespace Cesil.Tests
                () =>
                    Options.CreateBuilder(Options.Default)
                        .WithWhitespaceTreatmentInternal(WhitespaceTreatments.Trim)
-                       .WithValueSeparator(' ')
+                       .WithValueSeparator(' '.ToString())
                        .ToOptions()
            );
 
@@ -577,7 +577,7 @@ namespace Cesil.Tests
                () =>
                    Options.CreateBuilder(Options.Default)
                        .WithExtraColumnTreatmentInternal(0)
-                       .WithValueSeparator(' ')
+                       .WithValueSeparator(' '.ToString())
                        .ToOptions()
            );
 

--- a/Cesil.Tests/ConfigurationTests.cs
+++ b/Cesil.Tests/ConfigurationTests.cs
@@ -594,6 +594,78 @@ namespace Cesil.Tests
                         .WithEscapedValueEscapeCharacter('\\')
                         .ToOptions()
             );
+
+            // \r clashing
+            {
+                Options.CreateBuilder(Options.Default).WithValueSeparator("\r").WithRowEnding(RowEnding.LineFeed).ToOptions();
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r")
+                            .WithRowEnding(RowEnding.CarriageReturn)
+                            .ToOptions()
+                );
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r")
+                            .WithRowEnding(RowEnding.CarriageReturnLineFeed)
+                            .ToOptions()
+                );
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r")
+                            .WithRowEnding(RowEnding.Detect)
+                            .ToOptions()
+                );
+            }
+
+            // \n clashing
+            {
+                Options.CreateBuilder(Options.Default).WithValueSeparator("\n").WithRowEnding(RowEnding.CarriageReturn).ToOptions();
+                Options.CreateBuilder(Options.Default).WithValueSeparator("\n").WithRowEnding(RowEnding.CarriageReturnLineFeed).ToOptions();
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\n")
+                            .WithRowEnding(RowEnding.LineFeed)
+                            .ToOptions()
+                );
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\n")
+                            .WithRowEnding(RowEnding.Detect)
+                            .ToOptions()
+                );
+            }
+
+            // \r\n clashing
+            {
+                Options.CreateBuilder(Options.Default).WithValueSeparator("\n").WithRowEnding(RowEnding.CarriageReturnLineFeed).ToOptions();
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r\n")
+                            .WithRowEnding(RowEnding.CarriageReturnLineFeed)
+                            .ToOptions()
+                );
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r")
+                            .WithRowEnding(RowEnding.CarriageReturnLineFeed)
+                            .ToOptions()
+                );
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        Options.CreateBuilder(Options.Default)
+                            .WithValueSeparator("\r\n")
+                            .WithRowEnding(RowEnding.Detect)
+                            .ToOptions()
+                );
+            }
         }
 
         private class _BadCreateCalls

--- a/Cesil.Tests/DisposalTests.cs
+++ b/Cesil.Tests/DisposalTests.cs
@@ -1114,7 +1114,8 @@ namespace Cesil.Tests
                         new ReaderStateMachine(),
                         Options.Default,
                         CharacterLookup.MakeCharacterLookup(Options.Default, out _),
-                        new TextReaderAdapter(TextReader.Null)
+                        new TextReaderAdapter(TextReader.Null),
+                        Options.Default.ValueSeparator.AsMemory()
                     );
                 }
             }

--- a/Cesil.Tests/DynamicWriterTests.cs
+++ b/Cesil.Tests/DynamicWriterTests.cs
@@ -34,6 +34,84 @@ namespace Cesil.Tests
         }
 
         [Fact]
+        public void MultiCharacterValueSeparators()
+        {
+            var opts = Options.CreateBuilder(Options.DynamicDefault).WithValueSeparator("#*#").ToOptions();
+
+            // no escapes
+            {
+                var r1 = MakeDynamicRow("A,B\r\n123,foo");
+                var r2 = MakeDynamicRow("A,B\r\n456,#");
+                var r3 = MakeDynamicRow("A,B\r\n789,*");
+
+                RunSyncDynamicWriterVariants(
+                    opts,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            csv.Write(r1);
+                            csv.Write(r2);
+                            csv.Write(r3);
+                        }
+
+                        var res = getStr();
+                        Assert.Equal("A#*#B\r\n123#*#foo\r\n456#*##\r\n789#*#*", res);
+                    }
+                );
+            }
+
+            // escapes
+            {
+                var r1 = MakeDynamicRow("A,B\r\n123,foo#*#bar");
+                var r2 = MakeDynamicRow("A,B\r\n456,#");
+                var r3 = MakeDynamicRow("A,B\r\n789,*");
+
+                RunSyncDynamicWriterVariants(
+                   opts,
+                   (config, getWriter, getStr) =>
+                   {
+                       using (var writer = getWriter())
+                       using (var csv = config.CreateWriter(writer))
+                       {
+                           csv.Write(r1);
+                           csv.Write(r2);
+                           csv.Write(r3);
+                       }
+
+                       var res = getStr();
+                       Assert.Equal("A#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                   }
+               );
+            }
+
+            // in headers
+            {
+                var r1 = MakeDynamicRow("A#*#Escaped,B\r\n123,foo#*#bar");
+                var r2 = MakeDynamicRow("A#*#Escaped,B\r\n456,#");
+                var r3 = MakeDynamicRow("A#*#Escaped,B\r\n789,*");
+
+                RunSyncDynamicWriterVariants(
+                  opts,
+                  (config, getWriter, getStr) =>
+                  {
+                      using (var writer = getWriter())
+                      using (var csv = config.CreateWriter(writer))
+                      {
+                          csv.Write(r1);
+                          csv.Write(r2);
+                          csv.Write(r3);
+                      }
+
+                      var res = getStr();
+                      Assert.Equal("\"A#*#Escaped\"#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                  }
+              );
+            }
+        }
+
+        [Fact]
         public void WriteCommentBeforeRow()
         {
             // no headers
@@ -313,7 +391,7 @@ namespace Cesil.Tests
         {
             // no escapes at all (TSV)
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator('\t').WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator("\t").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 RunSyncDynamicWriterVariants(
@@ -390,7 +468,7 @@ namespace Cesil.Tests
 
             // escapes, but no escape for the escape start and end char
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator('\t').WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator("\t").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 RunSyncDynamicWriterVariants(
@@ -1841,6 +1919,84 @@ namespace Cesil.Tests
         // async tests
 
         [Fact]
+        public async Task MultiCharacterValueSeparatorsAsync()
+        {
+            var opts = Options.CreateBuilder(Options.DynamicDefault).WithValueSeparator("#*#").ToOptions();
+
+            // no escapes
+            {
+                var r1 = MakeDynamicRow("A,B\r\n123,foo");
+                var r2 = MakeDynamicRow("A,B\r\n456,#");
+                var r3 = MakeDynamicRow("A,B\r\n789,*");
+
+                await RunAsyncDynamicWriterVariants(
+                    opts,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            await csv.WriteAsync(r1);
+                            await csv.WriteAsync(r2);
+                            await csv.WriteAsync(r3);
+                        }
+
+                        var res = await getStr();
+                        Assert.Equal("A#*#B\r\n123#*#foo\r\n456#*##\r\n789#*#*", res);
+                    }
+                );
+            }
+
+            // escapes
+            {
+                var r1 = MakeDynamicRow("A,B\r\n123,foo#*#bar");
+                var r2 = MakeDynamicRow("A,B\r\n456,#");
+                var r3 = MakeDynamicRow("A,B\r\n789,*");
+
+                await RunAsyncDynamicWriterVariants(
+                   opts,
+                   async (config, getWriter, getStr) =>
+                   {
+                       await using (var writer = getWriter())
+                       await using (var csv = config.CreateAsyncWriter(writer))
+                       {
+                           await csv.WriteAsync(r1);
+                           await csv.WriteAsync(r2);
+                           await csv.WriteAsync(r3);
+                       }
+
+                       var res = await getStr();
+                       Assert.Equal("A#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                   }
+               );
+            }
+
+            // in headers
+            {
+                var r1 = MakeDynamicRow("A#*#Escaped,B\r\n123,foo#*#bar");
+                var r2 = MakeDynamicRow("A#*#Escaped,B\r\n456,#");
+                var r3 = MakeDynamicRow("A#*#Escaped,B\r\n789,*");
+
+                await RunAsyncDynamicWriterVariants(
+                  opts,
+                  async (config, getWriter, getStr) =>
+                  {
+                      await using (var writer = getWriter())
+                      await using (var csv = config.CreateAsyncWriter(writer))
+                      {
+                          await csv.WriteAsync(r1);
+                          await csv.WriteAsync(r2);
+                          await csv.WriteAsync(r3);
+                      }
+
+                      var res = await getStr();
+                      Assert.Equal("\"A#*#Escaped\"#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                  }
+              );
+            }
+        }
+
+        [Fact]
         public async Task WriteCommentBeforeRowAsync()
         {
             // no headers
@@ -2094,7 +2250,7 @@ namespace Cesil.Tests
         {
             // no escapes at all (TSV)
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator('\t').WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator("\t").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 await RunAsyncDynamicWriterVariants(
@@ -2171,7 +2327,7 @@ namespace Cesil.Tests
 
             // escapes, but no escape for the escape start and end char
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator('\t').WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.DynamicDefault).WithValueSeparator("\t").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 await RunAsyncDynamicWriterVariants(

--- a/Cesil.Tests/NeedsEncodeHelper_AVX_Tests.cs
+++ b/Cesil.Tests/NeedsEncodeHelper_AVX_Tests.cs
@@ -6,6 +6,35 @@ namespace Cesil.Tests
     public class NeedsEncodeHelper_AVX_Tests
     {
         [Theory]
+        [InlineData("0123456789ABCDE", -1)]
+        [InlineData("0123456789ABCDEF", -1)]
+        [InlineData("0123456789ABCDEFG", -1)]
+
+        [InlineData("012#*#6789ABCDE", 3)]
+        [InlineData("0123456789ABC#*#", 13)]
+        [InlineData("#*#123456789ABCDEFG", 0)]
+
+        [InlineData("#123456789ABCDE", -1)]
+        [InlineData("#*23456789ABCDEF", -1)]
+        [InlineData("*#23456789ABCDEFG", -1)]
+
+        [InlineData("0123456789ABCD#", -1)]
+        [InlineData("0123456789ABCD#*", -1)]
+        [InlineData("0123456789ABCDEF#", -1)]
+
+        public unsafe void MultiCharacterValueSeparator(string txt, int expected)
+        {
+            var state = new NeedsEncodeHelper("#*#", '"', '#');
+
+            fixed (char* charPtr = txt)
+            {
+                var res = state.ContainsCharRequiringEncoding(charPtr, txt.Length);
+
+                Assert.Equal(expected, res);
+            }
+        }
+
+        [Theory]
         [InlineData("0123456789ABCDEFa", -1)]
         [InlineData("0123456789ABCDEF,", 16)]
         [InlineData("0123456789ABCDEFab", -1)]
@@ -19,7 +48,7 @@ namespace Cesil.Tests
 
             Assert.NotEqual(0, txt.Length % charsFor256Bits);
 
-            var state = new NeedsEncodeHelper(',', '"', '#');
+            var state = new NeedsEncodeHelper(",", '"', '#');
 
             fixed (char* charPtr = txt)
             {
@@ -45,7 +74,7 @@ namespace Cesil.Tests
 
             Assert.Equal(0, txt.Length % charsFor256Bits);
 
-            var state = new NeedsEncodeHelper(',', '"', '#');
+            var state = new NeedsEncodeHelper(",", '"', '#');
 
             fixed (char* charPtr = txt)
             {
@@ -58,7 +87,7 @@ namespace Cesil.Tests
         [Fact]
         public unsafe void LessThan256Bits()
         {
-            var state = new NeedsEncodeHelper(',', '"', '#');
+            var state = new NeedsEncodeHelper(",", '"', '#');
 
             for (var len = 0; len < 16; len++)
             {
@@ -98,9 +127,9 @@ namespace Cesil.Tests
         [InlineData("world", -1)]
         public unsafe void Simple(string txt, int expected)
         {
-            var s1 = new NeedsEncodeHelper(',', '"', '#');
-            var s2 = new NeedsEncodeHelper(',', '"', null);
-            var s3 = new NeedsEncodeHelper(',', null, null);
+            var s1 = new NeedsEncodeHelper(",", '"', '#');
+            var s2 = new NeedsEncodeHelper(",", '"', null);
+            var s3 = new NeedsEncodeHelper(",", null, null);
 
             fixed (char* charPtr = txt)
             {

--- a/Cesil.Tests/PublicInterfaceTests.cs
+++ b/Cesil.Tests/PublicInterfaceTests.cs
@@ -1941,8 +1941,7 @@ namespace Cesil.Tests
                     [typeof(object).GetTypeInfo()] = new[] { "obj", "context", "row", "value" },
                     [typeof(int).GetTypeInfo()] = new[] { "index", "sizeHint" },
                     [typeof(int?).GetTypeInfo()] = new[] { "sizeHint" },
-                    [typeof(string).GetTypeInfo()] = new[] { "name", "comment", "path", "data" },
-                    [typeof(char).GetTypeInfo()] = new[] { "valueSeparator" },
+                    [typeof(string).GetTypeInfo()] = new[] { "name", "comment", "path", "data", "valueSeparator" },
                     [typeof(char?).GetTypeInfo()] = new[] { "commentStart", "escapeStart", "escape" },
 
                     // system types

--- a/Cesil.Tests/ReaderTests.cs
+++ b/Cesil.Tests/ReaderTests.cs
@@ -3911,7 +3911,7 @@ namespace Cesil.Tests
             const string TSV = @"Foo	Bar
 ""hello""""world""	123
 ";
-            var opts = Options.CreateBuilder(Options.Default).WithEscapedValueStartAndEnd('"').WithValueSeparator('\t').ToOptions();
+            var opts = Options.CreateBuilder(Options.Default).WithEscapedValueStartAndEnd('"').WithValueSeparator("\t").ToOptions();
 
             RunSyncReaderVariants<_TabSeparator>(
                 opts,
@@ -10265,7 +10265,7 @@ mkay,{new DateTime(2001, 6, 6, 6, 6, 6, DateTimeKind.Local)},8675309,987654321.0
             const string TSV = @"Foo	Bar
 ""hello""""world""	123
 ";
-            var opts = Options.CreateBuilder(Options.Default).WithEscapedValueStartAndEnd('"').WithValueSeparator('\t').ToOptions();
+            var opts = Options.CreateBuilder(Options.Default).WithEscapedValueStartAndEnd('"').WithValueSeparator("\t").ToOptions();
 
             await RunAsyncReaderVariants<_TabSeparator>(
                 opts,

--- a/Cesil.Tests/RowEndingDetectorTests.cs
+++ b/Cesil.Tests/RowEndingDetectorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -52,7 +53,7 @@ namespace Cesil.Tests
             {
                 using (var charLookup = CharacterLookup.MakeCharacterLookup(config.Options, out _))
                 {
-                    var detector = new RowEndingDetector(new ReaderStateMachine(), config.Options, charLookup, new TextReaderAdapter(str));
+                    var detector = new RowEndingDetector(new ReaderStateMachine(), config.Options, charLookup, new TextReaderAdapter(str), config.Options.ValueSeparator.AsMemory());
                     var detect = detector.Detect();
                     Assert.True(detect.HasValue);
                     Assert.Equal(expected, detect.Value.Ending);
@@ -104,7 +105,7 @@ namespace Cesil.Tests
                         {
                             var stateMachine = configUnpin?.StateMachine ?? new ReaderStateMachine();
                             using (var charLookup = CharacterLookup.MakeCharacterLookup(cInner.Options, out _))
-                            using (var detector = new RowEndingDetector(stateMachine, cInner.Options, charLookup, str))
+                            using (var detector = new RowEndingDetector(stateMachine, cInner.Options, charLookup, str, cInner.Options.ValueSeparator.AsMemory()))
                             {
                                 if (configForced != null)
                                 {

--- a/Cesil.Tests/UtilsTests.cs
+++ b/Cesil.Tests/UtilsTests.cs
@@ -641,5 +641,34 @@ namespace Cesil.Tests
 
             Assert.Equal(expected, ix);
         }
+
+        [Theory]
+        
+        [InlineData("hello", "world", -1)]
+        
+        [InlineData(",ello", ",", 0)]
+        [InlineData("h,llo", ",", 1)]
+        [InlineData("he,lo", ",", 2)]
+        [InlineData("hel,o", ",", 3)]
+        [InlineData("hell,", ",", 4)]
+
+        [InlineData("hello", "#*", -1)]
+        [InlineData("#ello", "#*", -1)]
+        [InlineData("*ello", "#*", -1)]
+        [InlineData("#*llo", "#*", 0)]
+        [InlineData("h#*lo", "#*", 1)]
+        [InlineData("he#*o", "#*", 2)]
+        [InlineData("hel#*", "#*", 3)]
+        [InlineData("hell#", "#*", -1)]
+
+        [InlineData("##*lo", "#*", 1)]
+        [InlineData("#e#*o", "#*", 2)]
+        [InlineData("#el#*", "#*", 3)]
+        [InlineData("#ell#", "#*", -1)]
+        public void Find(string txt, string needle, int expected)
+        {
+            var ix = Utils.Find(txt, 0, needle);
+            Assert.Equal(expected, ix);
+        }
     }
 }

--- a/Cesil.Tests/WriterTests.cs
+++ b/Cesil.Tests/WriterTests.cs
@@ -17,6 +17,85 @@ namespace Cesil.Tests
 #pragma warning disable IDE1006
     public class WriterTests
     {
+        class _MultiCharacterValueSeparators
+        {
+            public int A { get; set; }
+            public string B { get; set; }
+        }
+
+        class _MultiCharacterValueSeparators_Headers
+        {
+            [DataMember(Name = "A#*#Escaped")]
+            public int A { get; set; }
+            public string B { get; set; }
+        }
+
+        [Fact]
+        public void MultiCharacterValueSeparators()
+        {
+            var opts = Options.CreateBuilder(Options.Default).WithValueSeparator("#*#").ToOptions();
+
+            // no escapes
+            {
+                RunSyncWriterVariants<_MultiCharacterValueSeparators>(
+                    opts,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            csv.Write(new _MultiCharacterValueSeparators { A = 123, B = "foo" });
+                            csv.Write(new _MultiCharacterValueSeparators { A = 456, B = "#" });
+                            csv.Write(new _MultiCharacterValueSeparators { A = 789, B = "*" });
+                        }
+
+                        var res = getStr();
+                        Assert.Equal("A#*#B\r\n123#*#foo\r\n456#*##\r\n789#*#*", res);
+                    }
+                );
+            }
+
+            // escapes
+            {
+                RunSyncWriterVariants<_MultiCharacterValueSeparators>(
+                   opts,
+                   (config, getWriter, getStr) =>
+                   {
+                       using (var writer = getWriter())
+                       using (var csv = config.CreateWriter(writer))
+                       {
+                           csv.Write(new _MultiCharacterValueSeparators { A = 123, B = "foo#*#bar" });
+                           csv.Write(new _MultiCharacterValueSeparators { A = 456, B = "#" });
+                           csv.Write(new _MultiCharacterValueSeparators { A = 789, B = "*" });
+                       }
+
+                       var res = getStr();
+                       Assert.Equal("A#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                   }
+               );
+            }
+
+            // in headers
+            {
+                RunSyncWriterVariants<_MultiCharacterValueSeparators_Headers>(
+                  opts,
+                  (config, getWriter, getStr) =>
+                  {
+                      using (var writer = getWriter())
+                      using (var csv = config.CreateWriter(writer))
+                      {
+                          csv.Write(new _MultiCharacterValueSeparators_Headers { A = 123, B = "foo#*#bar" });
+                          csv.Write(new _MultiCharacterValueSeparators_Headers { A = 456, B = "#" });
+                          csv.Write(new _MultiCharacterValueSeparators_Headers { A = 789, B = "*" });
+                      }
+
+                      var res = getStr();
+                      Assert.Equal("\"A#*#Escaped\"#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                  }
+              );
+            }
+        }
+
         private enum _WellKnownSingleColumns
         {
             Foo,
@@ -1263,7 +1342,7 @@ namespace Cesil.Tests
                 // default options can always encode
                 WriterBase<object>.CheckCanEncode("hello", Options.Default);
 
-                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator('\t').ToOptions();
+                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator("\t").ToOptions();
                 // but " isn't
                 var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode("\"", tsv));
                 Assert.Contains("'\"'", exc1.Message);
@@ -1274,6 +1353,24 @@ namespace Cesil.Tests
                 Assert.Contains("','", exc2.Message);
             }
 
+            // single span, multi-char
+            {
+                var opt = Options.CreateBuilder(Options.Default).WithValueSeparator("---").ToOptions();
+
+                // default options can always encode
+                WriterBase<object>.CheckCanEncode("hello", opt);
+
+                var noInnerEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).ToOptions();
+                // but " isn't
+                var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode("\"", noInnerEscape));
+                Assert.Contains("'\"'", exc1.Message);
+
+                var noEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).WithEscapedValueStartAndEnd(null).ToOptions();
+                // comma is not escapable
+                var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode("---", noEscape));
+                Assert.Contains("'---'", exc2.Message);
+            }
+
             // sequence of single span
             {
                 // default options can always encode
@@ -1281,7 +1378,7 @@ namespace Cesil.Tests
                 Assert.True(seq1.IsSingleSegment);
                 WriterBase<object>.CheckCanEncode(seq1, Options.Default);
 
-                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator('\t').ToOptions();
+                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator("\t").ToOptions();
                 // but " isn't
                 var seq2 = new ReadOnlySequence<char>("\"".AsMemory());
                 Assert.True(seq2.IsSingleSegment);
@@ -1296,6 +1393,30 @@ namespace Cesil.Tests
                 Assert.Contains("','", exc2.Message);
             }
 
+            // sequence of single span, multi-char
+            {
+                var opt = Options.CreateBuilder(Options.Default).WithValueSeparator("---").ToOptions();
+
+                // default options can always encode
+                var seq1 = new ReadOnlySequence<char>("hello".AsMemory());
+                Assert.True(seq1.IsSingleSegment);
+                WriterBase<object>.CheckCanEncode(seq1, opt);
+
+                var noInnerEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).ToOptions();
+                // but " isn't
+                var seq2 = new ReadOnlySequence<char>("\"".AsMemory());
+                Assert.True(seq2.IsSingleSegment);
+                var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq2, noInnerEscape));
+                Assert.Contains("'\"'", exc1.Message);
+
+                var noEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).WithEscapedValueStartAndEnd(null).ToOptions();
+                // comma is not escapable
+                var seq3 = new ReadOnlySequence<char>("---".AsMemory());
+                Assert.True(seq3.IsSingleSegment);
+                var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq3, noEscape));
+                Assert.Contains("'---'", exc2.Message);
+            }
+
             // sequence of multiple spans
             {
                 // default options can always encode
@@ -1303,7 +1424,7 @@ namespace Cesil.Tests
                 Assert.False(seq1.IsSingleSegment);
                 WriterBase<object>.CheckCanEncode(seq1, Options.Default);
 
-                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator('\t').ToOptions();
+                var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator("\t").ToOptions();
                 // but " isn't
                 var seq2 = Utils.Split("\" -".AsMemory(), " ".AsMemory());
                 Assert.False(seq2.IsSingleSegment);
@@ -1316,6 +1437,30 @@ namespace Cesil.Tests
                 Assert.False(seq3.IsSingleSegment);
                 var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq3, noEscape));
                 Assert.Contains("','", exc2.Message);
+            }
+
+            // sequence of multiple spans, multi-char
+            {
+                var opt = Options.CreateBuilder(Options.Default).WithValueSeparator("---").ToOptions();
+
+                // default options can always encode
+                var seq1 = Utils.Split("hel-lo".AsMemory(), "-".AsMemory());
+                Assert.False(seq1.IsSingleSegment);
+                WriterBase<object>.CheckCanEncode(seq1, opt);
+
+                var noInnerEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).ToOptions();
+                // but " isn't
+                var seq2 = Utils.Split("\" - ".AsMemory(), "-".AsMemory());
+                Assert.False(seq2.IsSingleSegment);
+                var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq2, noInnerEscape));
+                Assert.Contains("'\"'", exc1.Message);
+
+                var noEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).WithEscapedValueStartAndEnd(null).ToOptions();
+                // comma is not escapable
+                var seq3 = Utils.Split("--- !".AsMemory(), " ".AsMemory());
+                Assert.False(seq3.IsSingleSegment);
+                var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq3, noEscape));
+                Assert.Contains("'---'", exc2.Message);
             }
         }
 
@@ -1330,7 +1475,7 @@ namespace Cesil.Tests
         {
             // no escapes at all (TSV)
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator('\t').WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("\t").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 RunSyncWriterVariants<_NoEscapes>(
@@ -1407,7 +1552,7 @@ namespace Cesil.Tests
 
             // escapes, but no escape for the escape start and end char
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator('\t').WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("\t").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 RunSyncWriterVariants<_NoEscapes>(
@@ -1454,6 +1599,145 @@ namespace Cesil.Tests
                         using (var csv = config.CreateWriter(writer))
                         {
                             var inv = Assert.Throws<InvalidOperationException>(() => csv.Write(new _NoEscapes { Foo = "a\tbc", Bar = "\"" }));
+
+                            Assert.Equal("Tried to write a value contain '\"' which requires escaping the character in an escaped value, but no way to escape inside an escaped value is configured", inv.Message);
+                        }
+
+                        getStr();
+                    }
+                );
+            }
+        }
+
+        [Fact]
+        public void NoEscapesMultiCharacterSeparator()
+        {
+            // no escapes at all (TSV)
+            {
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("**").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+
+                // correct
+                RunSyncWriterVariants<_NoEscapes>(
+                    opts,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            csv.Write(new _NoEscapes { Foo = "abc", Bar = "123" });
+                            csv.Write(new _NoEscapes { Foo = "\"", Bar = "," });
+                        }
+
+                        var str = getStr();
+                        Assert.Equal("Foo**Bar\r\nabc**123\r\n\"**,", str);
+                    }
+                );
+
+                // explodes if there's an value separator in a value, since there are no escapes
+                {
+                    // \t
+                    RunSyncWriterVariants<_NoEscapes>(
+                        opts,
+                        (config, getWriter, getStr) =>
+                        {
+                            using (var writer = getWriter())
+                            using (var csv = config.CreateWriter(writer))
+                            {
+                                var inv = Assert.Throws<InvalidOperationException>(() => csv.Write(new _NoEscapes { Foo = "h**lo", Bar = "foo" }));
+
+                                Assert.Equal("Tried to write a value contain '**' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            getStr();
+                        }
+                    );
+
+                    // \r\n
+                    RunSyncWriterVariants<_NoEscapes>(
+                        opts,
+                        (config, getWriter, getStr) =>
+                        {
+                            using (var writer = getWriter())
+                            using (var csv = config.CreateWriter(writer))
+                            {
+                                var inv = Assert.Throws<InvalidOperationException>(() => csv.Write(new _NoEscapes { Foo = "foo", Bar = "\r\n" }));
+
+                                Assert.Equal("Tried to write a value contain '\r' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            getStr();
+                        }
+                    );
+
+                    var optsWithComment = OptionsBuilder.CreateBuilder(opts).WithCommentCharacter('#').ToOptions();
+                    // #
+                    RunSyncWriterVariants<_NoEscapes>(
+                        optsWithComment,
+                        (config, getWriter, getStr) =>
+                        {
+                            using (var writer = getWriter())
+                            using (var csv = config.CreateWriter(writer))
+                            {
+                                var inv = Assert.Throws<InvalidOperationException>(() => csv.Write(new _NoEscapes { Foo = "#", Bar = "fizz" }));
+
+                                Assert.Equal("Tried to write a value contain '#' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            getStr();
+                        }
+                    );
+                }
+            }
+
+            // escapes, but no escape for the escape start and end char
+            {
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("**").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+
+                // correct
+                RunSyncWriterVariants<_NoEscapes>(
+                    opts,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            csv.Write(new _NoEscapes { Foo = "a**bc", Bar = "#123" });
+                            csv.Write(new _NoEscapes { Foo = "\r", Bar = "," });
+                        }
+
+                        var str = getStr();
+                        Assert.Equal("Foo**Bar\r\n\"a**bc\"**#123\r\n\"\r\"**,", str);
+                    }
+                );
+
+                var optsWithComments = OptionsBuilder.CreateBuilder(opts).WithCommentCharacter('#').ToOptions();
+
+                // correct with comments
+                RunSyncWriterVariants<_NoEscapes>(
+                    optsWithComments,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            csv.Write(new _NoEscapes { Foo = "a**bc", Bar = "#123" });
+                            csv.Write(new _NoEscapes { Foo = "\r", Bar = "," });
+                        }
+
+                        var str = getStr();
+                        Assert.Equal("Foo**Bar\r\n\"a**bc\"**\"#123\"\r\n\"\r\"**,", str);
+                    }
+                );
+
+                // explodes if there's an escape start character in a value, since it can't be escaped
+                RunSyncWriterVariants<_NoEscapes>(
+                    opts,
+                    (config, getWriter, getStr) =>
+                    {
+                        using (var writer = getWriter())
+                        using (var csv = config.CreateWriter(writer))
+                        {
+                            var inv = Assert.Throws<InvalidOperationException>(() => csv.Write(new _NoEscapes { Foo = "a**bc", Bar = "\"" }));
 
                             Assert.Equal("Tried to write a value contain '\"' which requires escaping the character in an escaped value, but no way to escape inside an escaped value is configured", inv.Message);
                         }
@@ -4195,6 +4479,211 @@ namespace Cesil.Tests
         }
 
         [Fact]
+        public async Task NoEscapesMultiCharacterSeparatorAsync()
+        {
+            // no escapes at all (TSV)
+            {
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("**").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+
+                // correct
+                await RunAsyncWriterVariants<_NoEscapes>(
+                    opts,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            await csv.WriteAsync(new _NoEscapes { Foo = "abc", Bar = "123" });
+                            await csv.WriteAsync(new _NoEscapes { Foo = "\"", Bar = "," });
+                        }
+
+                        var str = await getStr();
+                        Assert.Equal("Foo**Bar\r\nabc**123\r\n\"**,", str);
+                    }
+                );
+
+                // explodes if there's an value separator in a value, since there are no escapes
+                {
+                    // \t
+                    await RunAsyncWriterVariants<_NoEscapes>(
+                        opts,
+                        async (config, getWriter, getStr) =>
+                        {
+                            await using (var writer = getWriter())
+                            await using (var csv = config.CreateAsyncWriter(writer))
+                            {
+                                var inv = await Assert.ThrowsAsync<InvalidOperationException>(async () => await csv.WriteAsync(new _NoEscapes { Foo = "h**lo", Bar = "foo" }));
+
+                                Assert.Equal("Tried to write a value contain '**' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            await getStr();
+                        }
+                    );
+
+                    // \r\n
+                    await RunAsyncWriterVariants<_NoEscapes>(
+                        opts,
+                        async (config, getWriter, getStr) =>
+                        {
+                            await using (var writer = getWriter())
+                            await using (var csv = config.CreateAsyncWriter(writer))
+                            {
+                                var inv = await Assert.ThrowsAsync<InvalidOperationException>(async () => await csv.WriteAsync(new _NoEscapes { Foo = "foo", Bar = "\r\n" }));
+
+                                Assert.Equal("Tried to write a value contain '\r' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            await getStr();
+                        }
+                    );
+
+                    var optsWithComment = OptionsBuilder.CreateBuilder(opts).WithCommentCharacter('#').ToOptions();
+                    // #
+                    await RunAsyncWriterVariants<_NoEscapes>(
+                        optsWithComment,
+                        async (config, getWriter, getStr) =>
+                        {
+                            await using (var writer = getWriter())
+                            await using (var csv = config.CreateAsyncWriter(writer))
+                            {
+                                var inv = await Assert.ThrowsAsync<InvalidOperationException>(async () => await csv.WriteAsync(new _NoEscapes { Foo = "#", Bar = "fizz" }));
+
+                                Assert.Equal("Tried to write a value contain '#' which requires escaping a value, but no way to escape a value is configured", inv.Message);
+                            }
+
+                            await getStr();
+                        }
+                    );
+                }
+            }
+
+            // escapes, but no escape for the escape start and end char
+            {
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("**").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+
+                // correct
+                await RunAsyncWriterVariants<_NoEscapes>(
+                    opts,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            await csv.WriteAsync(new _NoEscapes { Foo = "a**bc", Bar = "#123" });
+                            await csv.WriteAsync(new _NoEscapes { Foo = "\r", Bar = "," });
+                        }
+
+                        var str = await getStr();
+                        Assert.Equal("Foo**Bar\r\n\"a**bc\"**#123\r\n\"\r\"**,", str);
+                    }
+                );
+
+                var optsWithComments = OptionsBuilder.CreateBuilder(opts).WithCommentCharacter('#').ToOptions();
+
+                // correct with comments
+                await RunAsyncWriterVariants<_NoEscapes>(
+                    optsWithComments,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            await csv.WriteAsync(new _NoEscapes { Foo = "a**bc", Bar = "#123" });
+                            await csv.WriteAsync(new _NoEscapes { Foo = "\r", Bar = "," });
+                        }
+
+                        var str = await getStr();
+                        Assert.Equal("Foo**Bar\r\n\"a**bc\"**\"#123\"\r\n\"\r\"**,", str);
+                    }
+                );
+
+                // explodes if there's an escape start character in a value, since it can't be escaped
+                await RunAsyncWriterVariants<_NoEscapes>(
+                    opts,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            var inv = await Assert.ThrowsAsync<InvalidOperationException>(async () => await csv.WriteAsync(new _NoEscapes { Foo = "a**bc", Bar = "\"" }));
+
+                            Assert.Equal("Tried to write a value contain '\"' which requires escaping the character in an escaped value, but no way to escape inside an escaped value is configured", inv.Message);
+                        }
+
+                        await getStr();
+                    }
+                );
+            }
+        }
+
+        [Fact]
+        public async Task MultiCharacterValueSeparatorsAsync()
+        {
+            var opts = Options.CreateBuilder(Options.Default).WithValueSeparator("#*#").ToOptions();
+
+            // no escapes
+            {
+                await RunAsyncWriterVariants<_MultiCharacterValueSeparators>(
+                    opts,
+                    async (config, getWriter, getStr) =>
+                    {
+                        await using (var writer = getWriter())
+                        await using (var csv = config.CreateAsyncWriter(writer))
+                        {
+                            await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 123, B = "foo" });
+                            await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 456, B = "#" });
+                            await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 789, B = "*" });
+                        }
+
+                        var res = await getStr();
+                        Assert.Equal("A#*#B\r\n123#*#foo\r\n456#*##\r\n789#*#*", res);
+                    }
+                );
+            }
+
+            // escapes
+            {
+                await RunAsyncWriterVariants<_MultiCharacterValueSeparators>(
+                   opts,
+                   async (config, getWriter, getStr) =>
+                   {
+                       await using (var writer = getWriter())
+                       await using (var csv = config.CreateAsyncWriter(writer))
+                       {
+                           await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 123, B = "foo#*#bar" });
+                           await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 456, B = "#" });
+                           await csv.WriteAsync(new _MultiCharacterValueSeparators { A = 789, B = "*" });
+                       }
+
+                       var res = await getStr();
+                       Assert.Equal("A#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                   }
+               );
+            }
+
+            // in headers
+            {
+                await RunAsyncWriterVariants<_MultiCharacterValueSeparators_Headers>(
+                  opts,
+                  async (config, getWriter, getStr) =>
+                  {
+                      await using (var writer = getWriter())
+                      await using (var csv = config.CreateAsyncWriter(writer))
+                      {
+                          await csv.WriteAsync(new _MultiCharacterValueSeparators_Headers { A = 123, B = "foo#*#bar" });
+                          await csv.WriteAsync(new _MultiCharacterValueSeparators_Headers { A = 456, B = "#" });
+                          await csv.WriteAsync(new _MultiCharacterValueSeparators_Headers { A = 789, B = "*" });
+                      }
+
+                      var res = await getStr();
+                      Assert.Equal("\"A#*#Escaped\"#*#B\r\n123#*#\"foo#*#bar\"\r\n456#*##\r\n789#*#*", res);
+                  }
+              );
+            }
+        }
+
+        [Fact]
         public async Task WellKnownSingleColumnsAsync()
         {
             // bool
@@ -5340,7 +5829,7 @@ namespace Cesil.Tests
         {
             // no escapes at all (TSV)
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator('\t').WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("\t").WithEscapedValueStartAndEnd(null).WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 await RunAsyncWriterVariants<_NoEscapes>(
@@ -5417,7 +5906,7 @@ namespace Cesil.Tests
 
             // escapes, but no escape for the escape start and end char
             {
-                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator('\t').WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
+                var opts = OptionsBuilder.CreateBuilder(Options.Default).WithValueSeparator("\t").WithEscapedValueStartAndEnd('"').WithEscapedValueEscapeCharacter(null).ToOptions();
 
                 // correct
                 await RunAsyncWriterVariants<_NoEscapes>(

--- a/Cesil/Cesil.xml
+++ b/Cesil/Cesil.xml
@@ -513,7 +513,7 @@
             by this builder.
             </summary>
         </member>
-        <member name="M:Cesil.OptionsBuilder.WithValueSeparator(System.Char)">
+        <member name="M:Cesil.OptionsBuilder.WithValueSeparator(System.String)">
             <summary>
             Set the character used to separate two values in a row.
             </summary>

--- a/Cesil/Common/Utils.cs
+++ b/Cesil/Common/Utils.cs
@@ -307,16 +307,19 @@ tryAgain:
         private const int CHARS_PER_LONG = sizeof(long) / sizeof(char);
         private const int CHARS_PER_INT = sizeof(int) / sizeof(char);
 
-        internal static unsafe bool AreEqual(ReadOnlyMemory<char> a, ReadOnlyMemory<char> b)
+        internal static bool AreEqual(ReadOnlyMemory<char> a, ReadOnlyMemory<char> b)
+        => AreEqual(a.Span, b.Span);
+
+        internal static unsafe bool AreEqual(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
         {
             var aLen = a.Length;
             var bLen = b.Length;
             if (aLen != bLen) return false;
 
-            using (var aPin = a.Pin())
-            using (var bPin = b.Pin())
+            fixed (char* aPin = a)
+            fixed (char* bPin = b)
             {
-                return AreEqual(aLen, aPin.Pointer, bPin.Pointer);
+                return AreEqual(aLen, aPin, bPin);
             }
         }
 

--- a/Cesil/Common/Utils.cs
+++ b/Cesil/Common/Utils.cs
@@ -393,6 +393,50 @@ tryAgain:
             return ret + start;
         }
 
+        internal static int Find(ReadOnlySpan<char> span, int start, string str)
+        {
+            if (str.Length == 1)
+            {
+                return FindChar(span, start, str[0]);
+            }
+
+            var c1 = str[0];
+
+            var subset = span.Slice(start);
+            var ix = 0;
+            while (true)
+            {
+                var nextIx = FindChar(subset, ix, c1);
+                if (nextIx == -1)
+                {
+                    return -1;
+                }
+
+                if (str.Length + nextIx > subset.Length)
+                {
+                    return -1;
+                }
+
+                var tryAgain = false;
+                for (var i = 1; i < str.Length; i++)
+                {
+                    if (str[i] != subset[nextIx + i])
+                    {
+                        ix = nextIx + i;
+                        tryAgain = true;
+                        break;
+                    }
+                }
+
+                if (tryAgain)
+                {
+                    continue;
+                }
+
+                return nextIx + start;
+            }
+        }
+
         private static unsafe int FindChar(ReadOnlySpan<char> span, char c)
         {
             var cQuad =
@@ -554,6 +598,31 @@ tryAgain:
                 var curSegEnd = curSegStart + cur.Length;
 
                 var inSeg = FindChar(cur.Span, c);
+                if (inSeg != -1)
+                {
+                    return curSegStart + inSeg;
+                }
+
+                curSegStart = curSegEnd;
+            }
+
+            return -1;
+        }
+
+        internal static int Find(ReadOnlySequence<char> head, string str)
+        {
+            if (head.IsSingleSegment)
+            {
+                return Find(head.First.Span, 0, str);
+            }
+
+            var curSegStart = 0;
+
+            foreach (var cur in head)
+            {
+                var curSegEnd = curSegStart + cur.Length;
+
+                var inSeg = Find(cur.Span, 0, str);
                 if (inSeg != -1)
                 {
                     return curSegStart + inSeg;

--- a/Cesil/Configuration/BoundConfigurationBase.cs
+++ b/Cesil/Configuration/BoundConfigurationBase.cs
@@ -17,6 +17,7 @@ namespace Cesil
         public Options Options { get; }
 
         internal readonly ReadOnlyMemory<char> RowEndingMemory;
+        internal readonly ReadOnlyMemory<char> ValueSeparatorMemory;
 
         internal readonly DeserializableMember[] DeserializeColumns;
 
@@ -60,7 +61,10 @@ namespace Cesil
                     //     but construction is fine
                     _ => default
                 };
+
             NeedsEncode = new NeedsEncodeHelper(options.ValueSeparator, options.EscapedValueStartAndEnd, options.CommentCharacter);
+
+            ValueSeparatorMemory = options.ValueSeparator.AsMemory();
         }
 
         /// <summary>
@@ -89,7 +93,10 @@ namespace Cesil
                     //     but construction is fine
                     _ => default
                 };
+
             NeedsEncode = new NeedsEncodeHelper(options.ValueSeparator, options.EscapedValueStartAndEnd, options.CommentCharacter);
+
+            ValueSeparatorMemory = options.ValueSeparator.AsMemory();
         }
 
         public IAsyncReader<T> CreateAsyncReader(PipeReader reader, Encoding encoding, object? context = null)

--- a/Cesil/Configuration/Configuration.cs
+++ b/Cesil/Configuration/Configuration.cs
@@ -63,6 +63,10 @@ namespace Cesil
 
             var serializeColumns = CreateSerializeColumns(forType, options, serializeMembers);
 
+            char? escapeStartEnd = options.EscapedValueStartAndEnd;
+            var valueSep = options.ValueSeparator;
+            var startOfValSep = valueSep[0];
+
             // this is entirely knowable now, so go ahead and calculate
             //   and save for future use
             var needsEscape = new bool[serializeColumns.Length];
@@ -73,10 +77,37 @@ namespace Cesil
                 for (var j = 0; j < name.Length; j++)
                 {
                     var c = name[j];
-                    if (c == '\r' || c == '\n' || c == options.ValueSeparator || c == options.EscapedValueStartAndEnd)
+                    if (c == '\r' || c == '\n' || c == escapeStartEnd)
                     {
                         escape = true;
                         break;
+                    }
+
+                    if (c == startOfValSep)
+                    {
+                        var matchesSep = true;
+                        for (var k = 1; k < valueSep.Length; k++)
+                        {
+                            var nameCharIx = j + k;
+                            if (nameCharIx >= name.Length)
+                            {
+                                matchesSep = false;
+                                break;
+                            }
+
+                            var valSepChar = valueSep[k];
+                            if (valSepChar != name[nameCharIx])
+                            {
+                                matchesSep = false;
+                                break;
+                            }
+                        }
+
+                        if (matchesSep)
+                        {
+                            escape = true;
+                            break;
+                        }
                     }
                 }
 

--- a/Cesil/Configuration/NeedsEncodeHelper.cs
+++ b/Cesil/Configuration/NeedsEncodeHelper.cs
@@ -1,11 +1,12 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
 namespace Cesil
 {
-    [StructLayout(LayoutKind.Explicit, Size = sizeof(short) * PROBABILITY_MAP_SIZE + sizeof(short) * AVX_REGISTER_VALUES)]
+    [StructLayout(LayoutKind.Explicit, Size = 8 + sizeof(short) * PROBABILITY_MAP_SIZE + sizeof(short) * AVX_REGISTER_VALUES)]
     internal unsafe struct NeedsEncodeHelper
     {
         private const int PROBABILITY_MAP_SIZE = 16;
@@ -35,29 +36,34 @@ namespace Cesil
                 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF,
             };
 
+
         [FieldOffset(0)]
+        private readonly string ValueSeparator;
+
+        [FieldOffset(8)]
         internal fixed short MAP[PROBABILITY_MAP_SIZE];
 
-        [FieldOffset(END_OF_PROBILITY_MAP)]
+        [FieldOffset(8 + END_OF_PROBILITY_MAP)]
         private readonly short FirstChar;
 
-        [FieldOffset(END_OF_PROBILITY_MAP + sizeof(short) * 1)]
+        [FieldOffset(8 + END_OF_PROBILITY_MAP + sizeof(short) * 1)]
         private readonly short SecondChar;
 
-        [FieldOffset(END_OF_PROBILITY_MAP + sizeof(short) * 2)]
+        [FieldOffset(8 + END_OF_PROBILITY_MAP + sizeof(short) * 2)]
         private readonly short ThirdChar;
 
-        [FieldOffset(END_OF_PROBILITY_MAP + sizeof(short) * 3)]
+        [FieldOffset(8 + END_OF_PROBILITY_MAP + sizeof(short) * 3)]
         private readonly short Char2Mask;
-        [FieldOffset(END_OF_PROBILITY_MAP + sizeof(short) * 4)]
+        [FieldOffset(8 + END_OF_PROBILITY_MAP + sizeof(short) * 4)]
         private readonly short Char3Mask;
 
-        internal NeedsEncodeHelper(char c1, char? c2, char? c3)
+        internal NeedsEncodeHelper(string sep, char? c2, char? c3)
         {
-            FirstChar = (short)c1;
+            FirstChar = (short)sep[0];
+            ValueSeparator = sep;
             SecondChar = (short)(c2 ?? '\0');
             ThirdChar = (short)(c3 ?? '\0');
-
+            
             fixed (short* mapPtr = MAP)
             {
                 // put \r and \n in there
@@ -155,7 +161,9 @@ namespace Cesil
                 {
                     var charsToSkip = trailingZeros / sizeof(char);
 
-                    return i * CHARS_PER_VECTOR + charsToSkip;
+                    var charIx =  i * CHARS_PER_VECTOR + charsToSkip;
+                    var r = CheckValueSeparatorPresent(charIx, strPtr + charIx, len);
+                    if (r != -1) return r;
                 }
             }
 
@@ -234,7 +242,9 @@ namespace Cesil
                 {
                     var charsToSkip = trailingZeros / sizeof(char);
 
-                    return v256Count * CHARS_PER_VECTOR + charsToSkip;
+                    var charIx = v256Count * CHARS_PER_VECTOR + charsToSkip;
+                    var r = CheckValueSeparatorPresent(charIx, strPtr + charIx, len);
+                    if (r != -1) return r;
                 }
 
                 remainingIntPtr += remainingInts;
@@ -254,7 +264,8 @@ namespace Cesil
 
                 if (needEncode)
                 {
-                    return len - 1;
+                    var charIx = len - 1;
+                    return CheckValueSeparatorPresent(charIx, strPtr + charIx, len);
                 }
             }
 
@@ -274,7 +285,8 @@ tryAgain:
             var c = *strPtr;
             if (c == '\r' || c == '\n' || c == FirstChar || c == SecondChar || c == ThirdChar)
             {
-                return ix;
+                var r = CheckValueSeparatorPresent(ix, strPtr, len);
+                if (r != -1) return r;
             }
 
             strPtr++;
@@ -282,6 +294,37 @@ tryAgain:
             if (len <= 0) return -1;
 
             goto tryAgain;
+        }
+
+        // need to check the value separator, potentially
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private readonly int CheckValueSeparatorPresent(int ix, char* strPtr, int strLen)
+        {
+            // no need to do more checks
+            if (ValueSeparator.Length == 1) return ix;
+
+            // some other character, so no checks needed
+            var isValueSep = *strPtr == FirstChar;
+            if (!isValueSep) return ix;
+
+            var valueSepIx = 1;
+            var remaining = ValueSeparator.Length - valueSepIx;
+
+            // no space
+            if (strLen - (ix + 1) < remaining) return -1;
+
+            var ptr = strPtr + 1;
+            while(valueSepIx < ValueSeparator.Length)
+            {
+                var c = *ptr;
+                var sC = ValueSeparator[valueSepIx];
+                if (c != sC) return -1;
+
+                ptr++;
+                valueSepIx++;
+            }
+
+            return ix;
         }
 
         // inspired by https://github.com/bbowyersmyth/coreclr/blob/d59b674ee9cd6d092073f9d8d321f935a757e53d/src/classlibnative/bcltype/stringnative.cpp

--- a/Cesil/Configuration/Options.cs
+++ b/Cesil/Configuration/Options.cs
@@ -33,7 +33,7 @@ namespace Cesil
         /// </summary>
         public static readonly Options Default =
             CreateBuilder()
-                .WithValueSeparator(',')
+                .WithValueSeparator(",")
                 .WithRowEnding(RowEnding.CarriageReturnLineFeed)
                 .WithEscapedValueStartAndEnd('"')
                 .WithEscapedValueEscapeCharacter('"')
@@ -69,7 +69,7 @@ namespace Cesil
         /// </summary>
         public static readonly Options DynamicDefault =
             CreateBuilder()
-                .WithValueSeparator(',')
+                .WithValueSeparator(",")
                 .WithRowEnding(RowEnding.CarriageReturnLineFeed)
                 .WithEscapedValueStartAndEnd('"')
                 .WithEscapedValueEscapeCharacter('"')
@@ -91,7 +91,7 @@ namespace Cesil
         /// 
         /// Typically a comma.
         /// </summary>
-        public char ValueSeparator { get; }
+        public string ValueSeparator { get; }
         /// <summary>
         /// Character used to start an escaped value.
         /// 

--- a/Cesil/Configuration/OptionsBuilder.cs
+++ b/Cesil/Configuration/OptionsBuilder.cs
@@ -156,12 +156,12 @@ namespace Cesil
             }
 
             // can't distinguish between the start of a value and an empty value
-            if (ValueSeparator.Length == 1 && ValueSeparator[0] == EscapedValueStartAndEnd)
+            if (ValueSeparator[0] == EscapedValueStartAndEnd)
             {
                 return Throw.InvalidOperationException<Options>($"{nameof(ValueSeparator)} cannot equal {nameof(EscapedValueStartAndEnd)}, both are '{ValueSeparator}'");
             }
             // can't distinguish between the start of a comment and an empty value
-            if (ValueSeparator.Length == 1 && ValueSeparator[0] == CommentCharacter)
+            if (ValueSeparator[0] == CommentCharacter)
             {
                 return Throw.InvalidOperationException<Options>($"{nameof(ValueSeparator)} cannot equal {nameof(CommentCharacter)}, both are '{ValueSeparator}'");
             }
@@ -273,6 +273,11 @@ namespace Cesil
                 return Throw.ArgumentException<OptionsBuilder>($"{nameof(valueSeparator)} cannot be empty", nameof(valueSeparator));
             }
 
+            return WithValueSeparatorInternal(valueSeparator);
+        }
+
+        internal OptionsBuilder WithValueSeparatorInternal(string valueSeparator)
+        {
             ValueSeparator = valueSeparator;
             return this;
         }

--- a/Cesil/Configuration/OptionsBuilder.cs
+++ b/Cesil/Configuration/OptionsBuilder.cs
@@ -255,6 +255,22 @@ namespace Cesil
                 }
             }
 
+            // ValueSeparator can't be the same as the expected row ending
+            var valSepFirstChar = ValueSeparator[0];
+            var valSepIsCR = valSepFirstChar == '\r';
+            var valSepIsLF = valSepFirstChar == '\n';
+            var valSepIsRowEnding = valSepIsCR || valSepIsLF;
+
+            var valueSeparatorMatchesRowEnding =
+                (RowEnding == RowEnding.CarriageReturn && valSepIsCR) ||
+                (RowEnding == RowEnding.CarriageReturnLineFeed && valSepIsCR) ||    // only the first character matters, so valSepIsCR is what we want here
+                (RowEnding == RowEnding.LineFeed && valSepIsLF) ||
+                (RowEnding == RowEnding.Detect && valSepIsRowEnding);
+            if (valueSeparatorMatchesRowEnding)
+            {
+                return Throw.InvalidOperationException<Options>($"{nameof(ValueSeparator)} cannot match the expected (or potential for {nameof(RowEnding.Detect)}) {nameof(RowEnding)}");
+            }
+
             return BuildInternal();
         }
 

--- a/Cesil/Reader/AsyncReader.cs
+++ b/Cesil/Reader/AsyncReader.cs
@@ -65,10 +65,11 @@ namespace Cesil
 
             try
             {
+                var madeProgress = true;
                 while (true)
                 {
                     PreparingToWriteToBuffer();
-                    var availableTask = Buffer.ReadAsync(Inner, cancel);
+                    var availableTask = Buffer.ReadAsync(Inner, madeProgress, cancel);
                     if (!availableTask.IsCompletedSuccessfully(this))
                     {
 
@@ -91,7 +92,7 @@ namespace Cesil
                         StartRow();
                     }
 
-                    var res = AdvanceWork(available);
+                    var res = AdvanceWork(available, out madeProgress);
                     var possibleReturn = HandleAdvanceResult(res, returnComments, ending: false);
                     if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                     {
@@ -114,6 +115,8 @@ namespace Cesil
                 {
                     using (handle)
                     {
+                        bool madeProgress;
+
                         // finish this loop up
                         {
                             int available;
@@ -134,7 +137,7 @@ namespace Cesil
                                 self.StartRow();
                             }
 
-                            var res = self.AdvanceWork(available);
+                            var res = self.AdvanceWork(available, out madeProgress);
                             var possibleReturn = self.HandleAdvanceResult(res, returnComments, ending: false);
                             if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                             {
@@ -146,7 +149,7 @@ namespace Cesil
                         while (true)
                         {
                             self.PreparingToWriteToBuffer();
-                            var availableTask = self.Buffer.ReadAsync(self.Inner, cancel);
+                            var availableTask = self.Buffer.ReadAsync(self.Inner, madeProgress, cancel);
                             int available;
                             self.StateMachine.ReleasePinForAsync(availableTask);
                             {
@@ -165,7 +168,7 @@ namespace Cesil
                                 self.StartRow();
                             }
 
-                            var res = self.AdvanceWork(available);
+                            var res = self.AdvanceWork(available, out madeProgress);
                             var possibleReturn = self.HandleAdvanceResult(res, returnComments, ending: false);
                             if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                             {
@@ -195,7 +198,7 @@ namespace Cesil
             }
 
             var disposeDetector = true;
-            var detector = new RowEndingDetector(StateMachine, Configuration.Options, SharedCharacterLookup, Inner);
+            var detector = new RowEndingDetector(StateMachine, Configuration.Options, SharedCharacterLookup, Inner, Configuration.ValueSeparatorMemory);
             try
             {
                 var resTask = detector.DetectAsync(cancel);

--- a/Cesil/Reader/BufferWithPushback.cs
+++ b/Cesil/Reader/BufferWithPushback.cs
@@ -5,7 +5,8 @@ using System.Threading.Tasks;
 
 namespace Cesil
 {
-    internal sealed class BufferWithPushback : ITestableDisposable
+    internal sealed class BufferWithPushback :
+        ITestableDisposable
     {
         private readonly MemoryPool<char> MemoryPool;
 
@@ -58,31 +59,61 @@ namespace Cesil
             PushBack = BackingOwner.Memory.Slice(halfPoint);
         }
 
-        internal int Read(IReaderAdapter reader)
+        internal int Read(IReaderAdapter reader, bool canBeServedFromPushback)
         {
             if (InPushBack > 0)
             {
-                PushBack.Slice(0, InPushBack).CopyTo(Buffer);
+                PushBack[..InPushBack].CopyTo(Buffer);
 
-                var ret = InPushBack;
+                var fromBuffer = InPushBack;
                 InPushBack = 0;
-                return ret;
+                if (canBeServedFromPushback)
+                {
+                    return fromBuffer;
+                }
+
+                var newBytes = reader.Read(Buffer.Span[fromBuffer..]);
+
+                return newBytes + fromBuffer;
             }
 
             return reader.Read(Buffer.Span);
         }
 
-        internal ValueTask<int> ReadAsync(IAsyncReaderAdapter reader, CancellationToken cancel)
+        internal ValueTask<int> ReadAsync(IAsyncReaderAdapter reader, bool canBeServedFromPushback, CancellationToken cancel)
         {
             if (InPushBack > 0)
             {
-                PushBack.Slice(0, InPushBack).CopyTo(Buffer);
-                var ret = InPushBack;
+                PushBack[..InPushBack].CopyTo(Buffer);
+                var fromBuffer = InPushBack;
                 InPushBack = 0;
-                return new ValueTask<int>(ret);
+
+                if (canBeServedFromPushback)
+                {
+                    return new ValueTask<int>(fromBuffer);
+                }
+
+                // this is _so_ trivial I'm intentionally not doing the ITestableAsyncProvider here
+                var readRes = reader.ReadAsync(Buffer[fromBuffer..], cancel);
+                if (!readRes.IsCompletedSuccessfully)
+                {
+                    return ReadAsync_ContinueAfterReadAsync(readRes, fromBuffer);
+                }
+
+                var newBytes = readRes.Result;
+
+                return new ValueTask<int>(newBytes + fromBuffer);
             }
 
             return reader.ReadAsync(Buffer, cancel);
+
+            // wait for read to complete, then indicate total bytes available
+            static async ValueTask<int> ReadAsync_ContinueAfterReadAsync(ValueTask<int> waitFor, int fromBuffer)
+            {
+                var newBytes = await waitFor;
+
+                return newBytes + fromBuffer;
+            }
         }
 
         internal void PushBackFromBuffer(int readCount, int pushBackCount)

--- a/Cesil/Reader/CharacterLookup.cs
+++ b/Cesil/Reader/CharacterLookup.cs
@@ -62,11 +62,7 @@ namespace Cesil
             var memoryPool = options.MemoryPool;
             var escapeStartChar = options.EscapedValueStartAndEnd;
             var valueSeparatorChar = options.ValueSeparator[0];
-            // todo: implement multi-char value separators
-            if(options.ValueSeparator.Length > 1)
-            {
-                throw new NotImplementedException();
-            }
+            var valueSepIsMultiChar = options.ValueSeparator.Length > 1;
             var escapeChar = options.EscapedValueEscapeCharacter;
             var commentChar = options.CommentCharacter;
 
@@ -133,7 +129,14 @@ namespace Cesil
                     }
                     else if (c == valueSeparatorChar)
                     {
-                        cType = CharacterType.ValueSeparator;
+                        if (valueSepIsMultiChar)
+                        {
+                            cType = CharacterType.MaybeValueSeparator;
+                        }
+                        else
+                        {
+                            cType = CharacterType.ValueSeparator;
+                        }
                     }
                     else if (c == '\r')
                     {

--- a/Cesil/Reader/CharacterLookup.cs
+++ b/Cesil/Reader/CharacterLookup.cs
@@ -61,7 +61,12 @@ namespace Cesil
         {
             var memoryPool = options.MemoryPool;
             var escapeStartChar = options.EscapedValueStartAndEnd;
-            var valueSeparatorChar = options.ValueSeparator;
+            var valueSeparatorChar = options.ValueSeparator[0];
+            // todo: implement multi-char value separators
+            if(options.ValueSeparator.Length > 1)
+            {
+                throw new NotImplementedException();
+            }
             var escapeChar = options.EscapedValueEscapeCharacter;
             var commentChar = options.CommentCharacter;
 

--- a/Cesil/Reader/Dynamic/AsyncDynamicReader.cs
+++ b/Cesil/Reader/Dynamic/AsyncDynamicReader.cs
@@ -117,10 +117,11 @@ namespace Cesil
 
             try
             {
+                var madeProgress = true;
                 while (true)
                 {
                     PreparingToWriteToBuffer();
-                    var availableTask = Buffer.ReadAsync(Inner, cancel);
+                    var availableTask = Buffer.ReadAsync(Inner, madeProgress, cancel);
                     if (!availableTask.IsCompletedSuccessfully(this))
                     {
                         disposeHandle = false;
@@ -142,7 +143,7 @@ namespace Cesil
                         StartRow();
                     }
 
-                    var res = AdvanceWork(available);
+                    var res = AdvanceWork(available, out madeProgress);
                     var possibleReturn = HandleAdvanceResult(res, returnComments, ending: false);
                     if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                     {
@@ -165,6 +166,8 @@ namespace Cesil
                 {
                     using (handle)
                     {
+                        var madeProgress = true;
+
                         // finish this loop up
                         {
                             int available;
@@ -185,7 +188,7 @@ namespace Cesil
                                 self.StartRow();
                             }
 
-                            var res = self.AdvanceWork(available);
+                            var res = self.AdvanceWork(available, out madeProgress);
                             var possibleReturn = self.HandleAdvanceResult(res, returnComments, ending: false);
                             if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                             {
@@ -197,7 +200,7 @@ namespace Cesil
                         while (true)
                         {
                             self.PreparingToWriteToBuffer();
-                            var availableTask = self.Buffer.ReadAsync(self.Inner, cancel);
+                            var availableTask = self.Buffer.ReadAsync(self.Inner, madeProgress, cancel);
                             int available;
                             self.StateMachine.ReleasePinForAsync(availableTask);
                             {
@@ -216,7 +219,7 @@ namespace Cesil
                                 self.StartRow();
                             }
 
-                            var res = self.AdvanceWork(available);
+                            var res = self.AdvanceWork(available, out madeProgress);
                             var possibleReturn = self.HandleAdvanceResult(res, returnComments, ending: false);
                             if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                             {
@@ -382,7 +385,7 @@ namespace Cesil
                 return default;
             }
 
-            var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner);
+            var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner, Configuration.ValueSeparatorMemory);
             var disposeDetector = true;
             try
             {

--- a/Cesil/Reader/Dynamic/DynamicReader.cs
+++ b/Cesil/Reader/Dynamic/DynamicReader.cs
@@ -87,11 +87,11 @@ namespace Cesil
 
             using (handle)
             {
-
+                var madeProgress = true;
                 while (true)
                 {
                     PreparingToWriteToBuffer();
-                    var available = Buffer.Read(Inner);
+                    var available = Buffer.Read(Inner, madeProgress);
                     if (available == 0)
                     {
                         var endRes = EndOfData();
@@ -104,7 +104,7 @@ namespace Cesil
                         StartRow();
                     }
 
-                    var res = AdvanceWork(available);
+                    var res = AdvanceWork(available, out madeProgress);
                     var possibleReturn = HandleAdvanceResult(res, returnComments, ending: false);
                     if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                     {
@@ -187,7 +187,7 @@ namespace Cesil
                 return;
             }
 
-            using (var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner))
+            using (var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner, Configuration.ValueSeparatorMemory))
             {
                 var res = detector.Detect();
                 HandleLineEndingsDetectionResult(res);

--- a/Cesil/Reader/Partial.cs
+++ b/Cesil/Reader/Partial.cs
@@ -50,6 +50,11 @@ namespace Cesil
             PendingCharacters.Append(from, atIndex, length);
         }
 
+        internal void AppendCharacters(ReadOnlySpan<char> from)
+        {
+            PendingCharacters.Append(from, 0, from.Length);
+        }
+
         internal void SkipCharacter()
         {
             PendingCharacters.Skipped();

--- a/Cesil/Reader/Reader.cs
+++ b/Cesil/Reader/Reader.cs
@@ -32,11 +32,11 @@ namespace Cesil
 
             using (handle)
             {
-
+                var madeProgress = true;
                 while (true)
                 {
                     PreparingToWriteToBuffer();
-                    var available = Buffer.Read(Inner);
+                    var available = Buffer.Read(Inner, madeProgress);
                     if (available == 0)
                     {
                         var endRes = EndOfData();
@@ -49,7 +49,7 @@ namespace Cesil
                         StartRow();
                     }
 
-                    var res = AdvanceWork(available);
+                    var res = AdvanceWork(available, out madeProgress);
                     var possibleReturn = HandleAdvanceResult(res, returnComments, ending: false);
                     if (possibleReturn.ResultType != ReadWithCommentResultType.NoValue)
                     {
@@ -103,7 +103,7 @@ namespace Cesil
                 return;
             }
 
-            using (var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner))
+            using (var detector = new RowEndingDetector(StateMachine, options, SharedCharacterLookup, Inner, Configuration.ValueSeparatorMemory))
             {
                 var res = detector.Detect();
                 HandleLineEndingsDetectionResult(res);

--- a/Cesil/Reader/ReaderBase.cs
+++ b/Cesil/Reader/ReaderBase.cs
@@ -40,6 +40,13 @@ namespace Cesil
                 bufferSize = Utils.DEFAULT_BUFFER_SIZE;
             }
 
+            // always need to be able to store a whole value separator "character"
+            var bufferMinSize = config.ValueSeparatorMemory.Length * 2;
+            if (bufferSize < bufferMinSize)
+            {
+                bufferSize = bufferMinSize;
+            }
+
             var memPool = options.MemoryPool;
 
             Buffer =
@@ -56,7 +63,7 @@ namespace Cesil
             ExtraColumnTreatment = extraTreatment;
         }
 
-        protected internal ReadWithCommentResultType AdvanceWork(int numInBuffer)
+        protected internal ReadWithCommentResultType AdvanceWork(int numInBuffer, out bool madeProgress)
         {
             var res = ProcessBuffer(numInBuffer, out var pushBack);
             if (pushBack > 0)
@@ -65,6 +72,7 @@ namespace Cesil
                 Buffer.PushBackFromBuffer(numInBuffer, pushBack);
             }
 
+            madeProgress = pushBack != numInBuffer;
             return res;
         }
 
@@ -108,9 +116,67 @@ namespace Cesil
             for (var i = 0; i < bufferLen; i++)
             {
                 var c = buffSpan[i];
-                var res = StateMachine.Advance(c);
+                var res = StateMachine.Advance(c, false);
 
-                var state = StateMachine.CurrentState;
+                var advanceIBy = 0;
+
+                // we only see this _if_ there are multiple characters in the separator, which is rare
+                if (res == ReaderStateMachine.AdvanceResult.LookAhead_MultiCharacterSeparator)
+                {
+                    var valSepLen = Configuration.ValueSeparatorMemory.Length;
+                    
+                    // do we have enough in the buffer to look ahead?
+                    var canCheckForSeparator = bufferLen - i >= valSepLen;
+                    if (canCheckForSeparator)
+                    {
+                        var shouldMatch = buffSpan.Slice(i, valSepLen);
+                        var eq = Utils.AreEqual(shouldMatch, Configuration.ValueSeparatorMemory.Span);
+                        if (eq)
+                        {
+                            // treat it like a value separator
+                            res = StateMachine.AdvanceValueSeparator();
+                            // advance further to the last character in the separator
+                            advanceIBy = valSepLen - 1;
+                        }
+                        else
+                        {
+                            res = StateMachine.Advance(c, true);
+                        }
+                    }
+                    else
+                    {
+                        // we don't have enough in the buffer... so deal with any running batches and ask for more
+                        if (inBatchableResult != null)
+                        {
+                            switch (inBatchableResult.Value)
+                            {
+                                case ReaderStateMachine.AdvanceResult.Skip_Character:
+
+                                    // there's no distinction between skipping several characters and skipping one
+                                    //    so this doesn't need the length
+                                    Partial.SkipCharacter();
+                                    break;
+                                case ReaderStateMachine.AdvanceResult.Append_Character:
+                                    var length = i - consistentResultSince;
+
+                                    Partial.AppendCharacters(buffSpan, consistentResultSince, length);
+                                    break;
+                                default:
+                                    unprocessedCharacters = default;
+                                    return Throw.ImpossibleException<ReadWithCommentResultType>($"Unexpected {nameof(ReaderStateMachine.AdvanceResult)}: {inBatchableResult.Value}", Configuration.Options);
+                            }
+                        }
+
+                        // we need to keep everything
+                        unprocessedCharacters = bufferLen - i;
+                        return ReadWithCommentResultType.NoValue;
+                    }
+                }
+
+                var handledUpTo = i;
+
+                // we _might_ need to modify i a bit if we just processed the fallout from a multi-char value separator
+                i += advanceIBy;
 
                 // try and batch skips and appends
                 //   to save time on copying AND on 
@@ -132,7 +198,7 @@ namespace Cesil
                                 Partial.SkipCharacter();
                                 break;
                             case ReaderStateMachine.AdvanceResult.Append_Character:
-                                var length = i - consistentResultSince;
+                                var length = handledUpTo - consistentResultSince;
 
                                 Partial.AppendCharacters(buffSpan, consistentResultSince, length);
                                 break;
@@ -169,6 +235,15 @@ namespace Cesil
                     case ReaderStateMachine.AdvanceResult.Append_CarriageReturnAndCurrentCharacter:
                         Partial.AppendCarriageReturn(buffSpan);
                         Partial.AppendCharacters(buffSpan, i, 1);
+                        break;
+
+                    case ReaderStateMachine.AdvanceResult.Append_ValueSeparator:
+                        Partial.AppendCharacters(Configuration.ValueSeparatorMemory.Span);
+                        break;
+
+                    case ReaderStateMachine.AdvanceResult.Append_CarriageReturnAndValueSeparator:
+                        Partial.AppendCarriageReturn(buffSpan);
+                        Partial.AppendCharacters(Configuration.ValueSeparatorMemory.Span);
                         break;
 
                     // cannot reach ReaderStateMachine.AdvanceResult.Append_CarriageReturnAndEndComment, because that only happens

--- a/Cesil/Reader/ReaderStateMachine.TransitionMatrix.cs
+++ b/Cesil/Reader/ReaderStateMachine.TransitionMatrix.cs
@@ -15,6 +15,8 @@ namespace Cesil
             Append_Character,
             Append_CarriageReturnAndCurrentCharacter,
             Append_CarriageReturnAndEndComment,
+            Append_ValueSeparator,
+            Append_CarriageReturnAndValueSeparator,
 
             Finished_Unescaped_Value,
             Finished_Escaped_Value,
@@ -23,6 +25,8 @@ namespace Cesil
             Finished_LastValueEscaped_Record,
 
             Finished_Comment,
+
+            LookAhead_MultiCharacterSeparator,
 
             Exception_InvalidState,
             Exception_StartEscapeInValue,
@@ -85,16 +89,17 @@ namespace Cesil
         {
             None = 0,
 
-            EscapeStartAndEnd,  // normally "
-            Escape,             // normally also "
-            ValueSeparator,     // normally ,
-            CarriageReturn,     // always \r
-            LineFeed,           // always \n
-            CommentStart,       // often not set, but normally # if set
-            Whitespace,         // anything considered a whitespace character
-            Other,              // any character not one of the above
+            EscapeStartAndEnd,      // normally "
+            Escape,                 // normally also "
+            ValueSeparator,         // normally ,
+            CarriageReturn,         // always \r
+            LineFeed,               // always \n
+            CommentStart,           // often not set, but normally # if set
+            Whitespace,             // anything considered a whitespace character
+            MaybeValueSeparator,    // if the value separator is multiple characters, the first character that makes it up
+            Other,                  // any character not one of the above
 
-            DataEnd             // special end of data symbol
+            DataEnd                 // special end of data symbol
         }
 
         internal readonly struct TransitionRule
@@ -117,7 +122,7 @@ namespace Cesil
         }
 
         internal const int RuleCacheStateCount = 55;            // max VALUE of State enum, + 1
-        internal const int RuleCacheCharacterCount = 10;        // count of CharacterType enum
+        internal const int RuleCacheCharacterCount = 11;        // count of CharacterType enum
         internal const int RuleCacheRowEndingCount = 5;         // max VALUE of RowEndings enum + 1
 
         internal const int RuleCacheConfigCount = RuleCacheRowEndingCount * 2 * 2 * 2 * 2;              // # line endings, escape char == escape start, reading or not reading comments, trimming / not trimming leading whitespace, trimming / not trimming trailing whitespace
@@ -271,7 +276,7 @@ namespace Cesil
                 // "
                 innerRet[(int)CharacterType.EscapeStartAndEnd] = Comment_BeforeHeader_Append_CarriageReturn_And_Current_Character;
                 // ,
-                innerRet[(int)CharacterType.ValueSeparator] = Comment_BeforeHeader_Append_CarriageReturn_And_Current_Character;
+                innerRet[(int)CharacterType.ValueSeparator] = Comment_BeforeHeader_Append_CarriageReturn_And_ValueSeparator;
                 // # (or whatever)
                 innerRet[(int)CharacterType.CommentStart] = Comment_BeforeHeader_Append_CarriageReturn_And_Current_Character;
 
@@ -335,7 +340,7 @@ namespace Cesil
                 // "
                 innerRet[(int)CharacterType.EscapeStartAndEnd] = Comment_BeforeRecord_Append_CarriageReturn_And_Current_Character;
                 // ,
-                innerRet[(int)CharacterType.ValueSeparator] = Comment_BeforeRecord_Append_CarriageReturn_And_Current_Character;
+                innerRet[(int)CharacterType.ValueSeparator] = Comment_BeforeRecord_Append_CarriageReturn_And_ValueSeparator;
                 // # (or whatever)
                 innerRet[(int)CharacterType.CommentStart] = Comment_BeforeRecord_Append_CarriageReturn_And_Current_Character;
 
@@ -397,6 +402,11 @@ namespace Cesil
                     Comment_BeforeRecord_Append_Character :
                     Comment_BeforeRecord_Skip_Character;
 
+            var onValueSep =
+                readComments ?
+                    Comment_BeforeRecord_Append_ValueSeparator :
+                    Comment_BeforeRecord_Skip_Character;
+
             var commentEndTreatment =
                 readComments ?
                     Record_Start_Finished_Comment :
@@ -407,7 +417,7 @@ namespace Cesil
             // "
             innerRet[(int)CharacterType.EscapeStartAndEnd] = commentCharacterTreatment;
             // ,
-            innerRet[(int)CharacterType.ValueSeparator] = commentCharacterTreatment;
+            innerRet[(int)CharacterType.ValueSeparator] = onValueSep;
             // # (or whatever)
             innerRet[(int)CharacterType.CommentStart] = commentCharacterTreatment;
 
@@ -462,6 +472,11 @@ namespace Cesil
                     Comment_BeforeHeader_Append_Character :
                     Comment_BeforeHeader_Skip_Character;
 
+            var valueSepTreatment =
+                readComments ?
+                    Comment_BeforeHeader_Append_ValueSeparator :
+                    Comment_BeforeHeader_Skip_Character;
+
             var commentEndTreatment =
                 readComments ?
                     Header_Start_Finished_Comment :
@@ -472,7 +487,7 @@ namespace Cesil
             // "
             innerRet[(int)CharacterType.EscapeStartAndEnd] = commentCharacterTreatment;
             // ,
-            innerRet[(int)CharacterType.ValueSeparator] = commentCharacterTreatment;
+            innerRet[(int)CharacterType.ValueSeparator] = valueSepTreatment;
             // # (or whatever)
             innerRet[(int)CharacterType.CommentStart] = commentCharacterTreatment;
 
@@ -1118,7 +1133,7 @@ namespace Cesil
             }
 
             // "df,
-            innerRet[(int)CharacterType.ValueSeparator] = Record_InEscapedValue_Append_Character;
+            innerRet[(int)CharacterType.ValueSeparator] = Record_InEscapedValue_Append_ValueSeparator;
             // "df\r
             innerRet[(int)CharacterType.CarriageReturn] = Record_InEscapedValue_Append_Character;
             // "df\n

--- a/Cesil/Reader/ReaderStateMachine.cs
+++ b/Cesil/Reader/ReaderStateMachine.cs
@@ -83,7 +83,7 @@ namespace Cesil
         internal AdvanceResult EndOfData()
         => AdvanceInner(CurrentState, CharacterType.DataEnd);
 
-        internal unsafe AdvanceResult Advance(char c)
+        internal unsafe AdvanceResult Advance(char c, bool knownNotValueSeparator)
         {
             var fromState = CurrentState;
 
@@ -98,8 +98,23 @@ namespace Cesil
                 cType = CharLookup[cOffset.Value];
             }
 
+            if(cType == CharacterType.MaybeValueSeparator)
+            {
+                if (!knownNotValueSeparator)
+                {
+                    return AdvanceResult.LookAhead_MultiCharacterSeparator;
+                }
+                else
+                {
+                    cType = CharacterType.Other;
+                }
+            }
+
             return AdvanceInner(fromState, cType);
         }
+
+        internal AdvanceResult AdvanceValueSeparator()
+        => AdvanceInner(CurrentState, CharacterType.ValueSeparator);
 
         // internal for testing purposes
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Cesil/Reader/TransitionRules.cs
+++ b/Cesil/Reader/TransitionRules.cs
@@ -22,6 +22,7 @@ namespace Cesil
         internal static readonly TransitionRule Record_ExpectingEndOfRecord_Skip_Character = (State.Record_ExpectingEndOfRecord, AdvanceResult.Skip_Character);
         internal static readonly TransitionRule Invalid_Exception_InvalidState = (State.Invalid, AdvanceResult.Exception_InvalidState);
         internal static readonly TransitionRule Record_InEscapedValue_Append_Character = (State.Record_InEscapedValue, AdvanceResult.Append_Character);
+        internal static readonly TransitionRule Record_InEscapedValue_Append_ValueSeparator = (State.Record_InEscapedValue, AdvanceResult.Append_ValueSeparator);
         internal static readonly TransitionRule Header_InEscapedValue_Skip_Character = (State.Header_InEscapedValue, AdvanceResult.Skip_Character);
 
         internal static readonly TransitionRule Header_Unescaped_NoValue_Skip_Character = (State.Header_Unescaped_NoValue, AdvanceResult.Skip_Character);
@@ -45,7 +46,10 @@ namespace Cesil
         internal static readonly TransitionRule Comment_BeforeRecord_Skip_Character = (State.Comment_BeforeRecord, AdvanceResult.Skip_Character);
 
         internal static readonly TransitionRule Comment_BeforeHeader_Append_Character = (State.Comment_BeforeHeader, AdvanceResult.Append_Character);
+        internal static readonly TransitionRule Comment_BeforeHeader_Append_ValueSeparator = (State.Comment_BeforeHeader, AdvanceResult.Append_ValueSeparator);
+
         internal static readonly TransitionRule Comment_BeforeRecord_Append_Character = (State.Comment_BeforeRecord, AdvanceResult.Append_Character);
+        internal static readonly TransitionRule Comment_BeforeRecord_Append_ValueSeparator = (State.Comment_BeforeRecord, AdvanceResult.Append_ValueSeparator);
 
         internal static readonly TransitionRule Header_Start_Skip_Character = (State.Header_Start, AdvanceResult.Skip_Character);
         internal static readonly TransitionRule Header_Start_Finished_Comment = (State.Header_Start, AdvanceResult.Finished_Comment);
@@ -59,7 +63,10 @@ namespace Cesil
         internal static readonly TransitionRule Comment_BeforeRecord_ExpectingEndOfComment_Append_Character = (State.Comment_BeforeRecord_ExpectingEndOfComment, AdvanceResult.Append_Character);
 
         internal static readonly TransitionRule Comment_BeforeHeader_Append_CarriageReturn_And_Current_Character = (State.Comment_BeforeHeader, AdvanceResult.Append_CarriageReturnAndCurrentCharacter);
+        internal static readonly TransitionRule Comment_BeforeHeader_Append_CarriageReturn_And_ValueSeparator = (State.Comment_BeforeHeader, AdvanceResult.Append_CarriageReturnAndValueSeparator);
+
         internal static readonly TransitionRule Comment_BeforeRecord_Append_CarriageReturn_And_Current_Character = (State.Comment_BeforeRecord, AdvanceResult.Append_CarriageReturnAndCurrentCharacter);
+        internal static readonly TransitionRule Comment_BeforeRecord_Append_CarriageReturn_And_ValueSeparator = (State.Comment_BeforeRecord, AdvanceResult.Append_CarriageReturnAndValueSeparator);
 
         internal static readonly TransitionRule Data_Ended_Skip_Character = (State.DataEnded, AdvanceResult.Skip_Character);
         internal static readonly TransitionRule Data_Ended_Finished_LastValueUnescaped_Record = (State.DataEnded, AdvanceResult.Finished_LastValueUnescaped_Record);

--- a/Cesil/Writer/AsyncWriter.cs
+++ b/Cesil/Writer/AsyncWriter.cs
@@ -437,7 +437,7 @@ namespace Cesil
         {
             if (needsSeparator)
             {
-                var sepTask = PlaceCharInStagingAsync(Configuration.Options.ValueSeparator, cancel);
+                var sepTask = PlaceInStagingAsync(Configuration.ValueSeparatorMemory, cancel);
                 if (!sepTask.IsCompletedSuccessfully(this))
                 {
                     return WriteColumnAsync_ContinueAfterSeparatorAsync(this, sepTask, row, colIx, col, cancel);
@@ -544,14 +544,14 @@ namespace Cesil
             var needsEscape = Configuration.SerializeColumnsNeedEscape;
 
             var columnsValue = Columns;
-            var valueSeparator = Configuration.Options.ValueSeparator;
+            var valueSeparator = Configuration.ValueSeparatorMemory;
 
             for (var i = 0; i < columnsValue.Length; i++)
             {
                 // for the separator
                 if (i != 0)
                 {
-                    var sepTask = PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var sepTask = PlaceInStagingAsync(valueSeparator, cancel);
                     if (!sepTask.IsCompletedSuccessfully(this))
                     {
                         return WriteHeadersAsync_CompleteAfterFlushAsync(this, sepTask, needsEscape, valueSeparator, i, cancel);
@@ -568,7 +568,7 @@ namespace Cesil
             return default;
 
             // waits for a flush to finish, then proceeds with writing headers
-            static async ValueTask WriteHeadersAsync_CompleteAfterFlushAsync(AsyncWriter<T> self, ValueTask waitFor, bool[] needsEscape, char valueSeparator, int i, CancellationToken cancel)
+            static async ValueTask WriteHeadersAsync_CompleteAfterFlushAsync(AsyncWriter<T> self, ValueTask waitFor, bool[] needsEscape, ReadOnlyMemory<char> valueSeparator, int i, CancellationToken cancel)
             {
                 await ConfigureCancellableAwait(self, waitFor, cancel);
                 CheckCancellation(self, cancel);
@@ -584,7 +584,7 @@ namespace Cesil
                 for (; i < selfColumnsValue.Length; i++)
                 {
                     // by definition we've always wrote at least one column here
-                    var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                     await ConfigureCancellableAwait(self, placeTask, cancel);
                     CheckCancellation(self, cancel);
 
@@ -595,7 +595,7 @@ namespace Cesil
             }
 
             // waits for a header write to finish, then proceeds with the rest
-            static async ValueTask WriteHeadersAsync_CompleteAfterHeaderWriteAsync(AsyncWriter<T> self, ValueTask waitFor, bool[] needsEscape, char valueSeparator, int i, CancellationToken cancel)
+            static async ValueTask WriteHeadersAsync_CompleteAfterHeaderWriteAsync(AsyncWriter<T> self, ValueTask waitFor, bool[] needsEscape, ReadOnlyMemory<char> valueSeparator, int i, CancellationToken cancel)
             {
                 await ConfigureCancellableAwait(self, waitFor, cancel);
                 CheckCancellation(self, cancel);
@@ -607,7 +607,7 @@ namespace Cesil
                 for (; i < selfColumnsValue.Length; i++)
                 {
                     // by definition we've always wrote at least one column here
-                    var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                     await ConfigureCancellableAwait(self, placeTask, cancel);
                     CheckCancellation(self, cancel);
 

--- a/Cesil/Writer/Dynamic/AsyncDynamicWriter.cs
+++ b/Cesil/Writer/Dynamic/AsyncDynamicWriter.cs
@@ -67,7 +67,7 @@ namespace Cesil
 
                 var options = Configuration.Options;
                 var typeDescriber = options.TypeDescriber;
-                var valueSeparator = options.ValueSeparator;
+                var valueSeparator = Configuration.ValueSeparatorMemory;
 
                 var writeHeadersTask = WriteHeadersAndEndRowIfNeededAsync(rowAsObj, cancel);
                 if (!writeHeadersTask.IsCompletedSuccessfully(this))
@@ -94,11 +94,11 @@ namespace Cesil
 
                         if (needsSeparator)
                         {
-                            var placeCharTask = PlaceCharInStagingAsync(valueSeparator, cancel);
-                            if (!placeCharTask.IsCompletedSuccessfully(this))
+                            var placeValueSepTask = PlaceInStagingAsync(valueSeparator, cancel);
+                            if (!placeValueSepTask.IsCompletedSuccessfully(this))
                             {
                                 disposeE = false;
-                                return WriteAsync_ContinueAfterPlaceCharAsync(this, placeCharTask, valueSeparator, cell, i, e, cancel);
+                                return WriteAsync_ContinueAfterPlaceCharAsync(this, placeValueSepTask, valueSeparator, cell, i, e, cancel);
                             }
                         }
 
@@ -161,7 +161,7 @@ end:
             }
 
             // continue after WriteHeadersAndRowIfNeededAsync completes
-            static async ValueTask WriteAsync_ContinueAfterWriteHeadersAsync(AsyncDynamicWriter self, ValueTask waitFor, dynamic row, ITypeDescriber typeDescriber, char valueSeparator, CancellationToken cancel)
+            static async ValueTask WriteAsync_ContinueAfterWriteHeadersAsync(AsyncDynamicWriter self, ValueTask waitFor, dynamic row, ITypeDescriber typeDescriber, ReadOnlyMemory<char> valueSeparator, CancellationToken cancel)
             {
                 try
                 {
@@ -182,7 +182,7 @@ end:
 
                         if (needsSeparator)
                         {
-                            var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                            var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                             await ConfigureCancellableAwait(self, placeTask, cancel);
                             CheckCancellation(self, cancel);
                         }
@@ -235,7 +235,7 @@ end:
             }
 
             // continue after PlaceCharInStagingAsync completes
-            static async ValueTask WriteAsync_ContinueAfterPlaceCharAsync(AsyncDynamicWriter self, ValueTask waitFor, char valueSeparator, DynamicCellValue cell, int i, IEnumerator<DynamicCellValue> e, CancellationToken cancel)
+            static async ValueTask WriteAsync_ContinueAfterPlaceCharAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> valueSeparator, DynamicCellValue cell, int i, IEnumerator<DynamicCellValue> e, CancellationToken cancel)
             {
                 try
                 {
@@ -296,7 +296,7 @@ end:
 
                             if (needsSeparator)
                             {
-                                var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                                var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                                 await ConfigureCancellableAwait(self, placeTask, cancel);
                                 CheckCancellation(self, cancel);
                             }
@@ -354,11 +354,10 @@ end:
             }
 
             // continue after WriteValueAsync completes
-            static async ValueTask WriteAsync_ContinueAfterWriteValueAsync(AsyncDynamicWriter self, ValueTask waitFor, char valueSeparator, int i, IEnumerator<DynamicCellValue> e, CancellationToken cancel)
+            static async ValueTask WriteAsync_ContinueAfterWriteValueAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> valueSeparator, int i, IEnumerator<DynamicCellValue> e, CancellationToken cancel)
             {
                 try
                 {
-
                     try
                     {
                         await ConfigureCancellableAwait(self, waitFor, cancel);
@@ -381,7 +380,7 @@ end:
 
                             if (needsSeparator)
                             {
-                                var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                                var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                                 await ConfigureCancellableAwait(self, placeTask, cancel);
                                 CheckCancellation(self, cancel);
                             }
@@ -962,7 +961,7 @@ end:
 
         private ValueTask WriteHeadersAsync(CancellationToken cancel)
         {
-            var valueSeparator = Configuration.Options.ValueSeparator;
+            var valueSeparator = Configuration.ValueSeparatorMemory;
 
             var columnNamesValue = ColumnNames.Value;
             for (var i = 0; i < columnNamesValue.Length; i++)
@@ -970,7 +969,7 @@ end:
                 if (i != 0)
                 {
                     // first value doesn't get a separator
-                    var placeCharTask = PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var placeCharTask = PlaceInStagingAsync(valueSeparator, cancel);
                     if (!placeCharTask.IsCompletedSuccessfully(this))
                     {
                         return WriteHeadersAsync_ContinueAfterStartOfForAsync(this, placeCharTask, valueSeparator, i, cancel);
@@ -1007,7 +1006,7 @@ end:
 
             // continue after a PlaceCharInStagingAsync or EndRecordAsync call
             //   we can share this because both branches go into the same next step
-            static async ValueTask WriteHeadersAsync_ContinueAfterStartOfForAsync(AsyncDynamicWriter self, ValueTask waitFor, char valueSeparator, int i, CancellationToken cancel)
+            static async ValueTask WriteHeadersAsync_ContinueAfterStartOfForAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> valueSeparator, int i, CancellationToken cancel)
             {
                 await ConfigureCancellableAwait(self, waitFor, cancel);
                 CheckCancellation(self, cancel);
@@ -1030,7 +1029,7 @@ end:
                 for (; i < selfColumnNamesValue.Length; i++)
                 {
                     // by definition i != 0, so no need for the if
-                    var secondPlaceTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var secondPlaceTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                     await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
                     CheckCancellation(self, cancel);
 
@@ -1044,7 +1043,7 @@ end:
                 }
             }
 
-            static async ValueTask WriteHeadersAsync_ContinueAfterPlaceInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, char valueSeparator, int i, CancellationToken cancel)
+            static async ValueTask WriteHeadersAsync_ContinueAfterPlaceInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> valueSeparator, int i, CancellationToken cancel)
             {
                 await ConfigureCancellableAwait(self, waitFor, cancel);
                 CheckCancellation(self, cancel);
@@ -1056,7 +1055,7 @@ end:
                 for (; i < selfColumnNamesValue.Length; i++)
                 {
                     // by definition i != 0, so no need for the if
-                    var placeTask = self.PlaceCharInStagingAsync(valueSeparator, cancel);
+                    var placeTask = self.PlaceInStagingAsync(valueSeparator, cancel);
                     await ConfigureCancellableAwait(self, placeTask, cancel);
                     CheckCancellation(self, cancel);
 

--- a/Cesil/Writer/Dynamic/DynamicWriter.cs
+++ b/Cesil/Writer/Dynamic/DynamicWriter.cs
@@ -61,6 +61,7 @@ namespace Cesil
                 var wholeRowContext = WriteContext.DiscoveringCells(Configuration.Options, RowNumber, Context);
 
                 var options = Configuration.Options;
+                var valueSeparator = Configuration.ValueSeparatorMemory.Span;
 
                 var cellValues = options.TypeDescriber.GetCellsForDynamicRow(in wholeRowContext, row as object);
                 cellValues = ForceInOrder(cellValues);
@@ -74,7 +75,7 @@ namespace Cesil
 
                     if (needsSeparator)
                     {
-                        PlaceCharInStaging(options.ValueSeparator);
+                        PlaceAllInStaging(valueSeparator);
                     }
 
                     ColumnIdentifier ci;
@@ -317,13 +318,15 @@ end:
 
         private void WriteHeaders()
         {
+            var valueSeparator = Configuration.ValueSeparatorMemory.Span;
+
             var columnNamesValue = ColumnNames.Value;
             for (var i = 0; i < columnNamesValue.Length; i++)
             {
                 if (i != 0)
                 {
                     // first value doesn't get a separator
-                    PlaceCharInStaging(Configuration.Options.ValueSeparator);
+                    PlaceAllInStaging(valueSeparator);
                 }
                 else
                 {

--- a/Cesil/Writer/Writer.cs
+++ b/Cesil/Writer/Writer.cs
@@ -12,6 +12,8 @@ namespace Cesil
         {
             try
             {
+                var valueSeparator = Configuration.ValueSeparatorMemory.Span;
+
                 WriteHeadersAndEndRowIfNeeded();
 
                 var columnsValue = Columns;
@@ -22,7 +24,7 @@ namespace Cesil
 
                     if (needsSeparator)
                     {
-                        PlaceCharInStaging(Configuration.Options.ValueSeparator);
+                        PlaceAllInStaging(valueSeparator);
                     }
 
                     var col = columnsValue[i];
@@ -150,13 +152,14 @@ namespace Cesil
             var columnsValue = Columns;
 
             var options = Configuration.Options;
+            var valueSeparator = Configuration.ValueSeparatorMemory.Span;
 
             for (var i = 0; i < columnsValue.Length; i++)
             {
                 // for the separator
                 if (i != 0)
                 {
-                    PlaceCharInStaging(options.ValueSeparator);
+                    PlaceAllInStaging(valueSeparator);
                 }
 
                 var colName = columnsValue[i].Name;

--- a/Cesil/Writer/WriterBase.cs
+++ b/Cesil/Writer/WriterBase.cs
@@ -110,8 +110,8 @@ namespace Cesil
                 // we can be slow here, we're about to throw an exception
                 var carriageReturnIx = Utils.FindChar(chars, 0, '\r');
                 var newLineIx = Utils.FindChar(chars, 0, '\n');
-                var separatorIx = Utils.FindChar(chars, 0, options.ValueSeparator);
 
+                var separatorIx = Utils.Find(chars, 0, options.ValueSeparator);
                 var commentChar = options.CommentCharacter;
                 var commentIx = commentChar != null ? Utils.FindChar(chars, 0, commentChar.Value) : -1;
 
@@ -121,9 +121,15 @@ namespace Cesil
                 if (commentIx == -1) commentIx = int.MaxValue;
 
                 var offendingIx = Math.Min(carriageReturnIx, Math.Min(newLineIx, Math.Min(separatorIx, commentIx)));
-                var offendingChar = chars[offendingIx];
 
-                Throw.InvalidOperationException<object>($"Tried to write a value contain '{offendingChar}' which requires escaping a value, but no way to escape a value is configured");
+                var take =
+                    carriageReturnIx == offendingIx ||
+                    newLineIx == offendingIx ||
+                    commentIx == offendingIx ? 1 : options.ValueSeparator.Length;
+
+                var offendingText = new string(chars[offendingIx..(offendingIx + take)]);
+
+                Throw.InvalidOperationException<object>($"Tried to write a value contain '{offendingText}' which requires escaping a value, but no way to escape a value is configured");
                 return;
             }
 
@@ -158,7 +164,8 @@ namespace Cesil
                 // we can be slow here, we're about to throw an exception
                 var carriageReturnIx = Utils.FindChar(chars, 0, '\r');
                 var newLineIx = Utils.FindChar(chars, 0, '\n');
-                var separatorIx = Utils.FindChar(chars, 0, options.ValueSeparator);
+
+                var separatorIx = Utils.Find(chars, options.ValueSeparator);
 
                 var commentChar = options.CommentCharacter;
                 var commentIx = commentChar != null ? Utils.FindChar(chars, 0, commentChar.Value) : -1;
@@ -170,9 +177,14 @@ namespace Cesil
 
                 var offendingIx = Math.Min(carriageReturnIx, Math.Min(newLineIx, Math.Min(separatorIx, commentIx)));
 
-                var offendingChar = chars.Slice(offendingIx).First.Span[0];
+                var take =
+                    carriageReturnIx == offendingIx ||
+                    newLineIx == offendingIx ||
+                    commentIx == offendingIx ? 1 : options.ValueSeparator.Length;
 
-                Throw.InvalidOperationException<object>($"Tried to write a value contain '{offendingChar}' which requires escaping a value, but no way to escape a value is configured");
+                var offendingText = new string(chars.Slice(offendingIx).FirstSpan[0..take]);
+
+                Throw.InvalidOperationException<object>($"Tried to write a value contain '{offendingText}' which requires escaping a value, but no way to escape a value is configured");
                 return;
             }
 


### PR DESCRIPTION
Implements multi-character value separators.

Visible changes:
 - `Options.ValueSeparator` is now a string
    * It cannot be null or empty
    * It's first character cannot match any of the other special characters
    * If whitespace is being trimmed, it cannot contain whitespace

Internal notable changes:
 - It's now possible for a the reader state machine to need to look ahead, which can increase the frequency of characters being left in the pending buffer
 - Minimum memory needing for a read buffer is now `2 * (length of ValueSeparator)` instead of `2`