### PR TITLE
Adds Span & Memory overloads for writing comments

### DIFF
--- a/Cesil.Tests/Cesil.Tests.csproj
+++ b/Cesil.Tests/Cesil.Tests.csproj
@@ -23,6 +23,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="%27\**" />
+    <EmbeddedResource Remove="%27\**" />
+    <None Remove="%27\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Cesil.Tests/DisposalTests.cs
+++ b/Cesil.Tests/DisposalTests.cs
@@ -941,11 +941,19 @@ namespace Cesil.Tests
                 }
 
 
-                // WriteComment
+                // WriteComment(string)
                 {
                     var w = MakeWriter();
                     w.Dispose();
                     Assert.Throws<ObjectDisposedException>(() => w.WriteComment("foo"));
+                    testCases++;
+                }
+
+                // WriteComment(ReadOnlySpan)
+                {
+                    var w = MakeWriter();
+                    w.Dispose();
+                    Assert.Throws<ObjectDisposedException>(() => w.WriteComment("foo".AsSpan()));
                     testCases++;
                 }
 
@@ -1635,11 +1643,19 @@ namespace Cesil.Tests
                     testCases++;
                 }
 
-                // WriteComment
+                // WriteComment(string)
                 {
                     var w = MakeWriter();
                     w.Dispose();
                     Assert.Throws<ObjectDisposedException>(() => w.WriteComment("foo"));
+                    testCases++;
+                }
+
+                // WriteComment(ReadOnlySpan)
+                {
+                    var w = MakeWriter();
+                    w.Dispose();
+                    Assert.Throws<ObjectDisposedException>(() => w.WriteComment("foo".AsSpan()));
                     testCases++;
                 }
 
@@ -2182,11 +2198,19 @@ namespace Cesil.Tests
                     testCases++;
                 }
 
-                // WriteCommentAsync
+                // WriteCommentAsync(string)
                 {
                     var w = MakeWriter();
                     await w.DisposeAsync();
                     Assert.Throws<ObjectDisposedException>(() => w.WriteCommentAsync(""));
+                    testCases++;
+                }
+
+                // WriteCommentAsync(ReadOnlyMemory)
+                {
+                    var w = MakeWriter();
+                    await w.DisposeAsync();
+                    Assert.Throws<ObjectDisposedException>(() => w.WriteCommentAsync("".AsMemory()));
                     testCases++;
                 }
 
@@ -2334,11 +2358,19 @@ namespace Cesil.Tests
                     testCases++;
                 }
 
-                // WriteCommentAsync
+                // WriteCommentAsync(string)
                 {
                     var w = MakeWriter();
                     await w.DisposeAsync();
                     Assert.Throws<ObjectDisposedException>(() => w.WriteCommentAsync(""));
+                    testCases++;
+                }
+
+                // WriteCommentAsync(ReadOnlyMemory)
+                {
+                    var w = MakeWriter();
+                    await w.DisposeAsync();
+                    Assert.Throws<ObjectDisposedException>(() => w.WriteCommentAsync("".AsMemory()));
                     testCases++;
                 }
 

--- a/Cesil.Tests/DynamicWriterTests.cs
+++ b/Cesil.Tests/DynamicWriterTests.cs
@@ -2238,7 +2238,7 @@ namespace Cesil.Tests
                     await using (var w = getWriter())
                     await using (var csv = config.CreateAsyncWriter(w))
                     {
-                        await Assert.ThrowsAsync<ArgumentNullException>(async () => await csv.WriteCommentAsync(null));
+                        await Assert.ThrowsAsync<ArgumentNullException>(async () => await csv.WriteCommentAsync(default(string)));
                     }
 
                     var res = await getStr();

--- a/Cesil.Tests/PublicInterfaceTests.cs
+++ b/Cesil.Tests/PublicInterfaceTests.cs
@@ -1957,7 +1957,8 @@ namespace Cesil.Tests
                     [typeof(TextReader).GetTypeInfo()] = new[] { "reader" },
                     [typeof(PipeReader).GetTypeInfo()] = new[] { "reader" },
                     [typeof(MemoryPool<char>).GetTypeInfo()] = new[] { "memoryPool" },
-                    [typeof(ReadOnlySpan<char>).GetTypeInfo()] = new[] { "data" },
+                    [typeof(ReadOnlySpan<char>).GetTypeInfo()] = new[] { "data", "comment" },
+                    [typeof(ReadOnlyMemory<char>).GetTypeInfo()] = new[] { "comment" },
                     [typeof(IEnumerable<dynamic>).GetTypeInfo()] = new[] { "rows" },
                     [typeof(IAsyncEnumerable<dynamic>).GetTypeInfo()] = new[] { "rows" },
 

--- a/Cesil.Tests/UtilsTests.cs
+++ b/Cesil.Tests/UtilsTests.cs
@@ -227,35 +227,6 @@ namespace Cesil.Tests
             Assert.Equal(expected, trimmedStr);
         }
 
-        [Theory]
-        [InlineData("", "\r\n")]
-        [InlineData("hello\r\nworld", "\r\n")]
-        [InlineData("hello world", " ")]
-        [InlineData("hello_world__foo_+bar_+_+_+_+wooo_+", "_+")]
-        [InlineData("\r\n", "\r\n")]
-        [InlineData(" \r\n", "\r\n")]
-        [InlineData("\r\n ", "\r\n")]
-        [InlineData(" \r\n ", "\r\n")]
-        [InlineData("#", "#")]
-        [InlineData("#", "###")]
-        [InlineData("nothing to break on", "foo")]
-        public void Split(string haystack, string needle)
-        {
-            var shouldMatch = haystack.Split(needle, StringSplitOptions.RemoveEmptyEntries);
-
-            var actually = Utils.Split(haystack.AsMemory(), needle.AsMemory());
-            var actuallySegments = new List<string>();
-            foreach (var seq in actually)
-            {
-                if (seq.Length != 0)
-                {
-                    actuallySegments.Add(new string(seq.Span));
-                }
-            }
-
-            Assert.True(shouldMatch.SequenceEqual(actuallySegments));
-        }
-
         private class _Encode
         {
             public string Foo { get; set; }

--- a/Cesil.Tests/WriterTests.cs
+++ b/Cesil.Tests/WriterTests.cs
@@ -1299,20 +1299,20 @@ namespace Cesil.Tests
             // sequence of multiple spans
             {
                 // default options can always encode
-                var seq1 = Utils.Split("hel-lo".AsMemory(), "-".AsMemory());
+                var seq1 = Split("hel-lo".AsMemory(), "-".AsMemory());
                 Assert.False(seq1.IsSingleSegment);
                 WriterBase<object>.CheckCanEncode(seq1, Options.Default);
 
                 var tsv = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithValueSeparator('\t').ToOptions();
                 // but " isn't
-                var seq2 = Utils.Split("\" -".AsMemory(), " ".AsMemory());
+                var seq2 = Split("\" -".AsMemory(), " ".AsMemory());
                 Assert.False(seq2.IsSingleSegment);
                 var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq2, tsv));
                 Assert.Contains("'\"'", exc1.Message);
 
                 var noEscape = Options.CreateBuilder(Options.Default).WithEscapedValueEscapeCharacter(null).WithEscapedValueStartAndEnd(null).ToOptions();
                 // comma is not escapable
-                var seq3 = Utils.Split("----!, ".AsMemory(), "!".AsMemory());
+                var seq3 = Split("----!, ".AsMemory(), "!".AsMemory());
                 Assert.False(seq3.IsSingleSegment);
                 var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq3, noEscape));
                 Assert.Contains("','", exc2.Message);
@@ -5598,7 +5598,7 @@ namespace Cesil.Tests
                     await using (var writer = getWriter())
                     await using (var csv = config.CreateAsyncWriter(writer))
                     {
-                        await Assert.ThrowsAsync<ArgumentNullException>(async () => await csv.WriteCommentAsync(null));
+                        await Assert.ThrowsAsync<ArgumentNullException>(async () => await csv.WriteCommentAsync(default(string)));
                     }
 
                     var _ = await getStr();

--- a/Cesil.Tests/WriterTests.cs
+++ b/Cesil.Tests/WriterTests.cs
@@ -1525,20 +1525,20 @@ namespace Cesil.Tests
                 var opt = Options.CreateBuilder(Options.Default).WithValueSeparator("---").ToOptions();
 
                 // default options can always encode
-                var seq1 = Utils.Split("hel-lo".AsMemory(), "-".AsMemory());
+                var seq1 = Split("hel-lo".AsMemory(), "-".AsMemory());
                 Assert.False(seq1.IsSingleSegment);
                 WriterBase<object>.CheckCanEncode(seq1, opt);
 
                 var noInnerEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).ToOptions();
                 // but " isn't
-                var seq2 = Utils.Split("\" - ".AsMemory(), "-".AsMemory());
+                var seq2 = Split("\" - ".AsMemory(), "-".AsMemory());
                 Assert.False(seq2.IsSingleSegment);
                 var exc1 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq2, noInnerEscape));
                 Assert.Contains("'\"'", exc1.Message);
 
                 var noEscape = Options.CreateBuilder(opt).WithEscapedValueEscapeCharacter(null).WithEscapedValueStartAndEnd(null).ToOptions();
                 // comma is not escapable
-                var seq3 = Utils.Split("--- !".AsMemory(), " ".AsMemory());
+                var seq3 = Split("--- !".AsMemory(), " ".AsMemory());
                 Assert.False(seq3.IsSingleSegment);
                 var exc2 = Assert.Throws<InvalidOperationException>(() => WriterBase<object>.CheckCanEncode(seq3, noEscape));
                 Assert.Contains("'---'", exc2.Message);

--- a/Cesil/Cesil.xml
+++ b/Cesil/Cesil.xml
@@ -1588,6 +1588,19 @@
             if the underlying sink does not complete immediately.
             </summary>
         </member>
+        <member name="M:Cesil.IAsyncWriter`1.WriteCommentAsync(System.ReadOnlyMemory{System.Char},System.Threading.CancellationToken)">
+            <summary>
+            Write a comment as a row.
+            
+            Only supported if this IWriter's configuration has a way to indicate comments.
+            
+            If the comment contains the row ending character sequence, it will be written as multiple
+            comment lines.
+            
+            Will complete synchronously if possible, but will not block
+            if the underlying sink does not complete immediately.
+            </summary>
+        </member>
         <member name="T:Cesil.ImpossibleException">
             <summary>
             An exception that should never happen.
@@ -1685,6 +1698,16 @@
             </summary>
         </member>
         <member name="M:Cesil.IWriter`1.WriteComment(System.String)">
+            <summary>
+            Write a comment as a row.
+            
+            Only supported if this IWriter's configuration has a way to indicate comments.
+            
+            If the comment contains the row ending character sequence, it will be written as multiple
+            comment lines.
+            </summary>
+        </member>
+        <member name="M:Cesil.IWriter`1.WriteComment(System.ReadOnlySpan{System.Char})">
             <summary>
             Write a comment as a row.
             

--- a/Cesil/Common/Utils.cs
+++ b/Cesil/Common/Utils.cs
@@ -158,118 +158,39 @@ namespace Cesil
             return toCheck.Value;
         }
 
-        // won't return empty entries
-        internal static ReadOnlySequence<char> Split(ReadOnlyMemory<char> str, ReadOnlyMemory<char> with)
+        internal static int FindNextIx(int startAt, ReadOnlyMemory<char> haystack, ReadOnlyMemory<char> needle)
+        => FindNextIx(startAt, haystack.Span, needle.Span);
+
+        internal static int FindNextIx(int startAt, ReadOnlySpan<char> haystack, ReadOnlySpan<char> needle)
         {
-            var strSpan = str.Span;
-            var withSpan = with.Span;
-
-            var ix = FindNextIx(0, strSpan, withSpan);
-
-            if (ix == -1)
-            {
-                return new ReadOnlySequence<char>(str);
-            }
-
-            ReadOnlyCharSegment? head = null;
-            ReadOnlyCharSegment? tail = null;
-
-            var lastIx = 0;
-            while (ix != -1)
-            {
-                var len = ix - lastIx;
-                if (len > 0)
-                {
-                    var subset = str[lastIx..ix];
-                    if (head == null)
-                    {
-                        head = new ReadOnlyCharSegment(subset, len);
-                    }
-                    else
-                    {
-                        if (tail == null)
-                        {
-                            tail = head.Append(subset, len);
-                        }
-                        else
-                        {
-                            tail = tail.Append(subset, len);
-                        }
-                    }
-                }
-
-                lastIx = ix + with.Length;
-                ix = FindNextIx(lastIx, strSpan, withSpan);
-            }
-
-            if (lastIx != str.Length)
-            {
-                var len = str.Length - lastIx;
-                var end = str.Slice(lastIx);
-                if (head == null)
-                {
-                    head = new ReadOnlyCharSegment(end, len);
-
-                }
-                else
-                {
-                    if (tail == null)
-                    {
-                        tail = head.Append(end, len);
-                    }
-                    else
-                    {
-                        tail = tail.Append(end, len);
-                    }
-                }
-            }
-
-            if (head == null)
-            {
-                return ReadOnlySequence<char>.Empty;
-            }
-
-            if (tail == null)
-            {
-                return new ReadOnlySequence<char>(head.Memory);
-            }
-
-            var ret = new ReadOnlySequence<char>(head, 0, tail, tail.Memory.Length);
-
-            return ret;
-
-            // actually figure out the next end
-            static int FindNextIx(int startAt, ReadOnlySpan<char> haystack, ReadOnlySpan<char> needle)
-            {
-                var c = needle[0];
-                var lookupFrom = startAt;
+            var c = needle[0];
+            var lookupFrom = startAt;
 
 tryAgain:
 
-                var ix = FindChar(haystack, lookupFrom, c);
-                if (ix == -1) return -1;
+            var ix = FindChar(haystack, lookupFrom, c);
+            if (ix == -1) return -1;
 
-                for (var i = 1; i < needle.Length; i++)
+            for (var i = 1; i < needle.Length; i++)
+            {
+                var readIx = ix + i;
+                if (readIx == haystack.Length)
                 {
-                    var readIx = ix + i;
-                    if (readIx == haystack.Length)
-                    {
-                        // past the end
-                        return -1;
-                    }
-
-                    var shouldMatch = needle[i];
-                    var actuallyIs = haystack[readIx];
-                    if (shouldMatch != actuallyIs)
-                    {
-                        lookupFrom = readIx;
-                        goto tryAgain;
-                    }
+                    // past the end
+                    return -1;
                 }
 
-                // actually all matched, hooray!
-                return ix;
+                var shouldMatch = needle[i];
+                var actuallyIs = haystack[readIx];
+                if (shouldMatch != actuallyIs)
+                {
+                    lookupFrom = readIx;
+                    goto tryAgain;
+                }
             }
+
+            // actually all matched, hooray!
+            return ix;
         }
 
         internal static bool NullReferenceEquality<T>(T? a, T? b)

--- a/Cesil/Interface/IAsyncWriter.cs
+++ b/Cesil/Interface/IAsyncWriter.cs
@@ -47,5 +47,18 @@ namespace Cesil
         /// if the underlying sink does not complete immediately.
         /// </summary>
         ValueTask WriteCommentAsync(string comment, CancellationToken cancel = default);
+
+        /// <summary>
+        /// Write a comment as a row.
+        /// 
+        /// Only supported if this IWriter's configuration has a way to indicate comments.
+        /// 
+        /// If the comment contains the row ending character sequence, it will be written as multiple
+        /// comment lines.
+        /// 
+        /// Will complete synchronously if possible, but will not block
+        /// if the underlying sink does not complete immediately.
+        /// </summary>
+        ValueTask WriteCommentAsync(ReadOnlyMemory<char> comment, CancellationToken cancel = default);
     }
 }

--- a/Cesil/Interface/IWriter.cs
+++ b/Cesil/Interface/IWriter.cs
@@ -27,5 +27,15 @@ namespace Cesil
         /// comment lines.
         /// </summary>
         void WriteComment(string comment);
+
+        /// <summary>
+        /// Write a comment as a row.
+        /// 
+        /// Only supported if this IWriter's configuration has a way to indicate comments.
+        /// 
+        /// If the comment contains the row ending character sequence, it will be written as multiple
+        /// comment lines.
+        /// </summary>
+        void WriteComment(ReadOnlySpan<char> comment);
     }
 }

--- a/Cesil/Writer/AsyncWriterBase.cs
+++ b/Cesil/Writer/AsyncWriterBase.cs
@@ -615,7 +615,14 @@ namespace Cesil
 
         public abstract ValueTask WriteAsync(T row, CancellationToken cancel = default);
 
-        public abstract ValueTask WriteCommentAsync(string comment, CancellationToken cancel = default);
+        public ValueTask WriteCommentAsync(string comment, CancellationToken cancel = default)
+        {
+            Utils.CheckArgumentNull(comment, nameof(comment));
+
+            return WriteCommentAsync(comment.AsMemory(), cancel);
+        }
+
+        public abstract ValueTask WriteCommentAsync(ReadOnlyMemory<char> comment, CancellationToken cancel = default);
 
         public abstract ValueTask DisposeAsync();
     }

--- a/Cesil/Writer/Dynamic/AsyncDynamicWriter.cs
+++ b/Cesil/Writer/Dynamic/AsyncDynamicWriter.cs
@@ -439,12 +439,10 @@ end:
             }
         }
 
-        public override ValueTask WriteCommentAsync(string comment, CancellationToken cancel = default)
+        public override ValueTask WriteCommentAsync(ReadOnlyMemory<char> comment, CancellationToken cancel = default)
         {
             AssertNotDisposed(this);
             AssertNotPoisoned(Configuration);
-
-            Utils.CheckArgumentNull(comment, nameof(comment));
 
             try
             {
@@ -460,13 +458,14 @@ end:
                     }
                     else
                     {
-                        var checkHeaders = CheckHeadersAsync(null, cancel);
-                        if (!checkHeaders.IsCompletedSuccessfully(this))
+                        var checkHeadersTask = CheckHeadersAsync(null, cancel);
+                        if (!checkHeadersTask.IsCompletedSuccessfully(this))
                         {
-                            return WriteCommentAsync_ContinueAfterCheckHeadersAsync(this, checkHeaders, comment, cancel);
+                            return WriteCommentAsync_ContinueAfterCheckHeadersAsync(this, checkHeadersTask, comment, cancel);
                         }
 
-                        if (!checkHeaders.Result)
+                        var checkHeadersResult = checkHeadersTask.Result;
+                        if (!checkHeadersResult)
                         {
                             shouldEndRecord = false;
                         }
@@ -482,102 +481,120 @@ end:
                     }
                 }
 
-                var (commentChar, segments) = SplitCommentIntoLines(comment);
+                var options = Configuration.Options;
+                var commentCharNullable = options.CommentCharacter;
 
-                // we know we can write directly now
-                var isFirstRow = true;
-                var e = segments.GetEnumerator();
-                while (e.MoveNext())
+                if (commentCharNullable == null)
                 {
-                    HasWrittenComments = true;
+                    return Throw.InvalidOperationException<ValueTask>($"No {nameof(Options.CommentCharacter)} configured, cannot write a comment line");
+                }
 
-                    var seg = e.Current;
+                HasWrittenComments = true;
 
-                    if (!isFirstRow)
-                    {
-                        var endRowTask = EndRecordAsync(cancel);
-                        if (!endRowTask.IsCompletedSuccessfully(this))
-                        {
-                            return WriteCommentAsync_ContinueAfterEndRowAsync(this, endRowTask, commentChar, seg, e, cancel);
-                        }
-                    }
+                var commentChar = commentCharNullable.Value;
+                var rowEndingMem = Configuration.RowEndingMemory;
 
+                var splitIx = Utils.FindNextIx(0, comment, rowEndingMem);
+                if (splitIx == -1)
+                {
+                    // single segment
                     var placeCharTask = PlaceCharInStagingAsync(commentChar, cancel);
                     if (!placeCharTask.IsCompletedSuccessfully(this))
                     {
-                        return WriteCommentAsync_ContinueAfterPlaceCharAsync(this, placeCharTask, commentChar, seg, e, cancel);
+                        return WriteCommentAsync_ContinueAfterSingleSegmentPlaceCharInStagingAsync(this, placeCharTask, comment, cancel);
                     }
 
-                    if (seg.Length > 0)
+                    if (comment.Length > 0)
                     {
-                        var placeTask = PlaceInStagingAsync(seg, cancel);
-                        if (!placeTask.IsCompletedSuccessfully(this))
+                        var placeTask = PlaceInStagingAsync(comment, cancel);
+
+                        // doesn't matter if it's completed, since the client will await before making another call
+                        return placeTask;
+                    }
+                }
+                else
+                {
+                    // multi segment
+                    var prevIx = 0;
+
+                    var isFirstRow = true;
+                    while (splitIx != -1)
+                    {
+                        if (!isFirstRow)
                         {
-                            return WriteCommentAsync_ContinueAfterPlaceSegementAsync(this, placeTask, commentChar, e, cancel);
+                            var endRecordTask = EndRecordAsync(cancel);
+                            if (!endRecordTask.IsCompletedSuccessfully(this))
+                            {
+                                return WriteCommentAsync_ContinueAfterMultiSegementEndRecordAsync(this, endRecordTask, commentChar, comment, prevIx, splitIx, rowEndingMem, cancel);
+                            }
                         }
+
+                        var placeCharTask = PlaceCharInStagingAsync(commentChar, cancel);
+                        if (!placeCharTask.IsCompletedSuccessfully(this))
+                        {
+                            return WriteCommentAsync_ContinueAfterMultiSegmentPlaceCharInStagingAsync(this, placeCharTask, commentChar, comment, prevIx, splitIx, rowEndingMem, cancel);
+                        }
+
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            var placeInTask = PlaceInStagingAsync(segSpan, cancel);
+                            if (!placeInTask.IsCompletedSuccessfully(this))
+                            {
+                                return WriteCommentAsync_ContinueAfterMultiSegmentPlaceInStagingAsync(this, placeInTask, commentChar, comment, prevIx, splitIx, rowEndingMem, cancel);
+                            }
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+
+                        isFirstRow = false;
                     }
 
-                    isFirstRow = false;
-                }
+                    if (prevIx != comment.Length)
+                    {
+                        if (!isFirstRow)
+                        {
+                            var endRecordTask = EndRecordAsync(cancel);
+                            if (!endRecordTask.IsCompletedSuccessfully(this))
+                            {
+                                return WriteCommentAsync_ContinueAfterMultiSegmentFinalCommentEndRecordAsync(this, endRecordTask, commentChar, comment, prevIx, rowEndingMem, cancel);
+                            }
+                        }
 
-                return default;
+                        var placeCharTask = PlaceCharInStagingAsync(commentChar, cancel);
+                        if (!placeCharTask.IsCompletedSuccessfully(this))
+                        {
+                            return WriteCommentAsync_ContinueAfterMultiSegmentFinalCommentPlaceCharInStagingAsync(this, placeCharTask, comment, prevIx, rowEndingMem, cancel);
+                        }
+
+                        var segSpan = comment[prevIx..];
+                        var placeInTask = PlaceInStagingAsync(segSpan, cancel);
+
+                        // no need to wait, as the client must await before making another call
+                        return placeInTask;
+                    }
+                }
             }
             catch (Exception e)
             {
-                return Throw.PoisonAndRethrow<ValueTask>(this, e);
+                Throw.PoisonAndRethrow<object>(this, e);
             }
 
-            // continue after CheckHeadersAsync completes
-            static async ValueTask WriteCommentAsync_ContinueAfterCheckHeadersAsync(AsyncDynamicWriter self, ValueTask<bool> waitFor, string comment, CancellationToken cancel)
+            return default;
+
+            // continue after waiting, in multi segment case, for the final comment, for the comment start char to write
+            static async ValueTask WriteCommentAsync_ContinueAfterMultiSegmentFinalCommentPlaceCharInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> comment, int prevIx, ReadOnlyMemory<char> rowEndingMem, CancellationToken cancel)
             {
                 try
                 {
-
-                    var shouldEndRecord = true;
-
-                    var res = await ConfigureCancellableAwait(self, waitFor, cancel);
+                    await ConfigureCancellableAwait(self, waitFor, cancel);
                     CheckCancellation(self, cancel);
 
-                    if (!res)
-                    {
-                        shouldEndRecord = false;
-                    }
-
-                    if (shouldEndRecord)
-                    {
-                        var endTask = self.EndRecordAsync(cancel);
-                        await ConfigureCancellableAwait(self, endTask, cancel);
-                        CheckCancellation(self, cancel);
-                    }
-
-                    var (commentChar, segments) = self.SplitCommentIntoLines(comment);
-
-                    // we know we can write directly now
-                    var isFirstRow = true;
-                    foreach (var seg in segments)
-                    {
-                        self.HasWrittenComments = true;
-
-                        if (!isFirstRow)
-                        {
-                            var endTask = self.EndRecordAsync(cancel);
-                            await ConfigureCancellableAwait(self, endTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-
-                        var placeTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, placeTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
-                        {
-                            var secondPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-
-                        isFirstRow = false;
-                    }
+                    var segSpan = comment[prevIx..];
+                    var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                    await ConfigureCancellableAwait(self, placeTask, cancel);
+                    CheckCancellation(self, cancel);
                 }
                 catch (Exception e)
                 {
@@ -585,42 +602,22 @@ end:
                 }
             }
 
-            // continue after EndRecordAsync completes
-            static async ValueTask WriteCommentAsync_ContinueAfterEndRecordAsync(AsyncDynamicWriter self, ValueTask waitFor, string comment, CancellationToken cancel)
+            // continue after waiting, in multi segment case, for the final comment, for ending the record to finish
+            static async ValueTask WriteCommentAsync_ContinueAfterMultiSegmentFinalCommentEndRecordAsync(AsyncDynamicWriter self, ValueTask waitFor, char commentChar, ReadOnlyMemory<char> comment, int prevIx, ReadOnlyMemory<char> rowEndingMem, CancellationToken cancel)
             {
                 try
                 {
                     await ConfigureCancellableAwait(self, waitFor, cancel);
                     CheckCancellation(self, cancel);
 
-                    var (commentChar, segments) = self.SplitCommentIntoLines(comment);
+                    var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                    await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                    CheckCancellation(self, cancel);
 
-                    // we know we can write directly now
-                    var isFirstRow = true;
-                    foreach (var seg in segments)
-                    {
-                        self.HasWrittenComments = true;
-
-                        if (!isFirstRow)
-                        {
-                            var endTask = self.EndRecordAsync(cancel);
-                            await ConfigureCancellableAwait(self, endTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-
-                        var placeTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, placeTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
-                        {
-                            var secondPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-
-                        isFirstRow = false;
-                    }
+                    var segSpan = comment[prevIx..];
+                    var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                    await ConfigureCancellableAwait(self, placeTask, cancel);
+                    CheckCancellation(self, cancel);
                 }
                 catch (Exception e)
                 {
@@ -628,72 +625,8 @@ end:
                 }
             }
 
-            static async ValueTask WriteCommentAsync_ContinueAfterEndRowAsync(
-                AsyncDynamicWriter self,
-                ValueTask waitFor,
-                char commentChar,
-                ReadOnlyMemory<char> seg,
-                ReadOnlySequence<char>.Enumerator e,
-                CancellationToken cancel
-            )
-            {
-                try
-                {
-
-                    await ConfigureCancellableAwait(self, waitFor, cancel);
-                    CheckCancellation(self, cancel);
-
-                    // finish loop
-                    {
-                        var placeTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, placeTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
-                        {
-                            var secondPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-                    }
-
-                    // resume
-                    while (e.MoveNext())
-                    {
-                        seg = e.Current;
-
-                        // by definition, not in the first row so we can skip the if
-                        var endTask = self.EndRecordAsync(cancel);
-                        await ConfigureCancellableAwait(self, endTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        var thirdPlaceTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, thirdPlaceTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
-                        {
-                            var fourthPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, fourthPlaceTask, cancel);
-                            CheckCancellation(self, cancel);
-                        }
-                    }
-                }
-                catch (Exception exc)
-                {
-                    Throw.PoisonAndRethrow<object>(self, exc);
-                }
-            }
-
-            // continue after writing the comment start char completes
-            static async ValueTask WriteCommentAsync_ContinueAfterPlaceCharAsync(
-                AsyncDynamicWriter self,
-                ValueTask waitFor,
-                char commentChar,
-                ReadOnlyMemory<char> seg,
-                ReadOnlySequence<char>.Enumerator e,
-                CancellationToken cancel
-            )
+            // continue after waiting, in the multi segment case, for writing the comment mem to finish
+            static async ValueTask WriteCommentAsync_ContinueAfterMultiSegmentPlaceInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, char commentChar, ReadOnlyMemory<char> comment, int prevIx, int splitIx, ReadOnlyMemory<char> rowEndingMem, CancellationToken cancel)
             {
                 try
                 {
@@ -702,82 +635,418 @@ end:
 
                     // finish the loop
                     {
-                        if (seg.Length > 0)
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    while (splitIx != -1)
+                    {
+                        // not first row by definition, so no check
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
                         {
-                            var placeTask = self.PlaceInStagingAsync(seg, cancel);
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    if (prevIx != comment.Length)
+                    {
+                        // not first row by definition, so no check
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..];
+                        var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                        await ConfigureCancellableAwait(self, placeTask, cancel);
+                        CheckCancellation(self, cancel);
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    Throw.PoisonAndRethrow<object>(self, e);
+                }
+            }
+
+            // continue after waiting, in the multi sgement case, for writing the comment char to finish
+            static async ValueTask WriteCommentAsync_ContinueAfterMultiSegmentPlaceCharInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, char commentChar, ReadOnlyMemory<char> comment, int prevIx, int splitIx, ReadOnlyMemory<char> rowEndingMem, CancellationToken cancel)
+            {
+                try
+                {
+                    await ConfigureCancellableAwait(self, waitFor, cancel);
+                    CheckCancellation(self, cancel);
+
+                    // finish the loop
+                    {
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    while (splitIx != -1)
+                    {
+                        // not first row by definition, so no check
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    if (prevIx != comment.Length)
+                    {
+                        // not first by definition, so no check
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..];
+                        var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                        await ConfigureCancellableAwait(self, placeTask, cancel);
+                        CheckCancellation(self, cancel);
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    Throw.PoisonAndRethrow<object>(self, e);
+                }
+            }
+
+            // continue after waiting, in the multi segment case, for the record to end
+            static async ValueTask WriteCommentAsync_ContinueAfterMultiSegementEndRecordAsync(AsyncDynamicWriter self, ValueTask waitFor, char commentChar, ReadOnlyMemory<char> comment, int prevIx, int splitIx, ReadOnlyMemory<char> rowEndingMem, CancellationToken cancel)
+            {
+                try
+                {
+                    await ConfigureCancellableAwait(self, waitFor, cancel);
+                    CheckCancellation(self, cancel);
+
+                    // finish the loop
+                    {
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    while (splitIx != -1)
+                    {
+                        // not first row by definition, so no check
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+
+                        prevIx = splitIx + rowEndingMem.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+                    }
+
+                    if (prevIx != comment.Length)
+                    {
+                        // not first row, by definition
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        var segSpan = comment[prevIx..];
+                        var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                        await ConfigureCancellableAwait(self, placeTask, cancel);
+                        CheckCancellation(self, cancel);
+                    }
+
+                }
+                catch (Exception e)
+                {
+                    Throw.PoisonAndRethrow<object>(self, e);
+                }
+            }
+
+            // continue after waiting, in the single segment, for the comment char to finish writing
+            static async ValueTask WriteCommentAsync_ContinueAfterSingleSegmentPlaceCharInStagingAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> comment, CancellationToken cancel)
+            {
+                try
+                {
+                    await ConfigureCancellableAwait(self, waitFor, cancel);
+                    CheckCancellation(self, cancel);
+
+                    if (comment.Length > 0)
+                    {
+                        var placeTask = self.PlaceInStagingAsync(comment, cancel);
+                        await ConfigureCancellableAwait(self, placeTask, cancel);
+                        CheckCancellation(self, cancel);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Throw.PoisonAndRethrow<object>(self, e);
+                }
+            }
+
+            // continue after waiting for the record to end
+            static async ValueTask WriteCommentAsync_ContinueAfterEndRecordAsync(AsyncDynamicWriter self, ValueTask waitFor, ReadOnlyMemory<char> comment, CancellationToken cancel)
+            {
+                try
+                {
+                    await ConfigureCancellableAwait(self, waitFor, cancel);
+                    CheckCancellation(self, cancel);
+
+                    var options = self.Configuration.Options;
+                    var commentCharNullable = options.CommentCharacter;
+
+                    if (commentCharNullable == null)
+                    {
+                        Throw.InvalidOperationException<object>($"No {nameof(Options.CommentCharacter)} configured, cannot write a comment line");
+                        return;
+                    }
+
+                    var commentChar = commentCharNullable.Value;
+
+                    self.HasWrittenComments = true;
+
+                    var rowEndingMem = self.Configuration.RowEndingMemory;
+
+                    var splitIx = Utils.FindNextIx(0, comment, rowEndingMem);
+                    if (splitIx == -1)
+                    {
+                        // single segment
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                        CheckCancellation(self, cancel);
+
+                        if (comment.Length > 0)
+                        {
+                            var placeTask = self.PlaceInStagingAsync(comment, cancel);
                             await ConfigureCancellableAwait(self, placeTask, cancel);
                             CheckCancellation(self, cancel);
                         }
                     }
-
-                    // resume
-                    while (e.MoveNext())
+                    else
                     {
-                        seg = e.Current;
+                        // multi segment
+                        var prevIx = 0;
 
-                        // by definition, not in the first row so we can skip the if
-                        var endTask = self.EndRecordAsync(cancel);
-                        await ConfigureCancellableAwait(self, endTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        var secondPlaceTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
+                        var isFirstRow = true;
+                        while (splitIx != -1)
                         {
-                            var thirdPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, thirdPlaceTask, cancel);
+                            if (!isFirstRow)
+                            {
+                                var endRecordTask = self.EndRecordAsync(cancel);
+                                await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                            await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                            CheckCancellation(self, cancel);
+
+                            var segSpan = comment[prevIx..splitIx];
+                            if (segSpan.Length > 0)
+                            {
+                                var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                                await ConfigureCancellableAwait(self, placeTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            prevIx = splitIx + rowEndingMem.Length;
+                            splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+
+                            isFirstRow = false;
+                        }
+
+                        if (prevIx != comment.Length)
+                        {
+                            if (!isFirstRow)
+                            {
+                                var endRecordTask = self.EndRecordAsync(cancel);
+                                await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                            await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                            CheckCancellation(self, cancel);
+
+                            var segSpan = comment[prevIx..];
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
                             CheckCancellation(self, cancel);
                         }
                     }
                 }
-                catch (Exception exc)
+                catch (Exception e)
                 {
-                    Throw.PoisonAndRethrow<object>(self, exc);
+                    Throw.PoisonAndRethrow<object>(self, e);
                 }
             }
 
-            // continue after writing a chunk of the comment completes
-            static async ValueTask WriteCommentAsync_ContinueAfterPlaceSegementAsync(
-                AsyncDynamicWriter self,
-                ValueTask waitFor,
-                char commentChar,
-                ReadOnlySequence<char>.Enumerator e,
-                CancellationToken cancel
-            )
+            // continue after waiting for the headers check to complete
+            static async ValueTask WriteCommentAsync_ContinueAfterCheckHeadersAsync(AsyncDynamicWriter self, ValueTask<bool> waitFor, ReadOnlyMemory<char> comment, CancellationToken cancel)
             {
                 try
                 {
-
-                    await ConfigureCancellableAwait(self, waitFor, cancel);
+                    var shouldEndRecord = await ConfigureCancellableAwait(self, waitFor, cancel);
                     CheckCancellation(self, cancel);
 
-                    while (e.MoveNext())
+                    if (shouldEndRecord)
                     {
-                        var seg = e.Current;
+                        var endRecordTask = self.EndRecordAsync(cancel);
+                        await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                        CheckCancellation(self, cancel);
+                    }
 
-                        // by definition, not in the first row so we can skip the if
-                        var endTask = self.EndRecordAsync(cancel);
-                        await ConfigureCancellableAwait(self, endTask, cancel);
+                    var options = self.Configuration.Options;
+                    var commentCharNullable = options.CommentCharacter;
+
+                    if (commentCharNullable == null)
+                    {
+                        Throw.InvalidOperationException<object>($"No {nameof(Options.CommentCharacter)} configured, cannot write a comment line");
+                        return;
+                    }
+
+                    var commentChar = commentCharNullable.Value;
+
+                    self.HasWrittenComments = true;
+
+                    var rowEndingMem = self.Configuration.RowEndingMemory;
+
+                    var splitIx = Utils.FindNextIx(0, comment, rowEndingMem);
+                    if (splitIx == -1)
+                    {
+                        // single segment
+                        var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                        await ConfigureCancellableAwait(self, placeCharTask, cancel);
                         CheckCancellation(self, cancel);
 
-                        var placeTask = self.PlaceCharInStagingAsync(commentChar, cancel);
-                        await ConfigureCancellableAwait(self, placeTask, cancel);
-                        CheckCancellation(self, cancel);
-
-                        if (seg.Length > 0)
+                        if (comment.Length > 0)
                         {
-                            var secondPlaceTask = self.PlaceInStagingAsync(seg, cancel);
-                            await ConfigureCancellableAwait(self, secondPlaceTask, cancel);
+                            var placeTask = self.PlaceInStagingAsync(comment, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
                             CheckCancellation(self, cancel);
                         }
                     }
+                    else
+                    {
+                        // multi segment
+                        var prevIx = 0;
 
+                        var isFirstRow = true;
+                        while (splitIx != -1)
+                        {
+                            if (!isFirstRow)
+                            {
+                                var endRecordTask = self.EndRecordAsync(cancel);
+                                await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                            await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                            CheckCancellation(self, cancel);
+
+                            var segSpan = comment[prevIx..splitIx];
+                            if (segSpan.Length > 0)
+                            {
+                                var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                                await ConfigureCancellableAwait(self, placeTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            prevIx = splitIx + rowEndingMem.Length;
+                            splitIx = Utils.FindNextIx(prevIx, comment, rowEndingMem);
+
+                            isFirstRow = false;
+                        }
+
+                        if (prevIx != comment.Length)
+                        {
+                            if (!isFirstRow)
+                            {
+                                var endRecordTask = self.EndRecordAsync(cancel);
+                                await ConfigureCancellableAwait(self, endRecordTask, cancel);
+                                CheckCancellation(self, cancel);
+                            }
+
+                            var placeCharTask = self.PlaceCharInStagingAsync(commentChar, cancel);
+                            await ConfigureCancellableAwait(self, placeCharTask, cancel);
+                            CheckCancellation(self, cancel);
+
+                            var segSpan = comment[prevIx..];
+                            var placeTask = self.PlaceInStagingAsync(segSpan, cancel);
+                            await ConfigureCancellableAwait(self, placeTask, cancel);
+                            CheckCancellation(self, cancel);
+                        }
+                    }
                 }
-                catch (Exception exc)
+                catch (Exception e)
                 {
-                    Throw.PoisonAndRethrow<object>(self, exc);
+                    Throw.PoisonAndRethrow<object>(self, e);
                 }
             }
         }

--- a/Cesil/Writer/Dynamic/DynamicWriter.cs
+++ b/Cesil/Writer/Dynamic/DynamicWriter.cs
@@ -121,12 +121,10 @@ end:
             }
         }
 
-        public override void WriteComment(string comment)
+        public override void WriteComment(ReadOnlySpan<char> comment)
         {
             AssertNotDisposed(this);
             AssertNotPoisoned(Configuration);
-
-            Utils.CheckArgumentNull(comment, nameof(comment));
 
             try
             {
@@ -155,26 +153,67 @@ end:
                     EndRecord();
                 }
 
-                var (commentChar, segments) = SplitCommentIntoLines(comment);
+                var options = Configuration.Options;
+                var commentCharNullable = options.CommentCharacter;
 
-                // we know we can write directly now
-                var isFirstRow = true;
-                foreach (var seg in segments)
+                if (commentCharNullable == null)
                 {
-                    HasWrittenComments = true;
+                    Throw.InvalidOperationException<object>($"No {nameof(Options.CommentCharacter)} configured, cannot write a comment line");
+                    return;
+                }
 
-                    if (!isFirstRow)
-                    {
-                        EndRecord();
-                    }
+                HasWrittenComments = true;
 
+                var commentChar = commentCharNullable.Value;
+                var rowEndingSpan = Configuration.RowEndingMemory.Span;
+
+                var splitIx = Utils.FindNextIx(0, comment, rowEndingSpan);
+                if (splitIx == -1)
+                {
+                    // single segment
                     PlaceCharInStaging(commentChar);
-                    if (seg.Span.Length > 0)
+                    if (comment.Length > 0)
                     {
-                        PlaceAllInStaging(seg.Span);
+                        PlaceAllInStaging(comment);
+                    }
+                }
+                else
+                {
+                    // multi segment
+                    var prevIx = 0;
+
+                    var isFirstRow = true;
+                    while (splitIx != -1)
+                    {
+                        if (!isFirstRow)
+                        {
+                            EndRecord();
+                        }
+
+                        PlaceCharInStaging(commentChar);
+                        var segSpan = comment[prevIx..splitIx];
+                        if (segSpan.Length > 0)
+                        {
+                            PlaceAllInStaging(segSpan);
+                        }
+
+                        prevIx = splitIx + rowEndingSpan.Length;
+                        splitIx = Utils.FindNextIx(prevIx, comment, rowEndingSpan);
+
+                        isFirstRow = false;
                     }
 
-                    isFirstRow = false;
+                    if (prevIx != comment.Length)
+                    {
+                        if (!isFirstRow)
+                        {
+                            EndRecord();
+                        }
+
+                        PlaceCharInStaging(commentChar);
+                        var segSpan = comment[prevIx..];
+                        PlaceAllInStaging(segSpan);
+                    }
                 }
             }
             catch (Exception e)

--- a/Cesil/Writer/SyncWriterBase.cs
+++ b/Cesil/Writer/SyncWriterBase.cs
@@ -43,7 +43,14 @@ namespace Cesil
 
         internal abstract void WriteInner(T row);
 
-        public abstract void WriteComment(string comment);
+        public void WriteComment(string comment)
+        {
+            Utils.CheckArgumentNull(comment, nameof(comment));
+
+            WriteComment(comment.AsSpan());
+        }
+
+        public abstract void WriteComment(ReadOnlySpan<char> comment);
 
         internal void EndRecord()
         {

--- a/Cesil/Writer/WriterBase.cs
+++ b/Cesil/Writer/WriterBase.cs
@@ -74,24 +74,6 @@ namespace Cesil
             return InStaging == StagingMemory.Length;
         }
 
-        internal (char CommentChar, ReadOnlySequence<char> CommentLines) SplitCommentIntoLines(string comment)
-        {
-            var options = Configuration.Options;
-            var commentChar = options.CommentCharacter;
-
-            if (commentChar == null)
-            {
-                return Throw.InvalidOperationException<(char CommentChar, ReadOnlySequence<char> CommentLines)>($"No {nameof(Options.CommentCharacter)} configured, cannot write a comment line");
-            }
-
-            var commentMem = comment.AsMemory();
-
-            var seq = Utils.Split(commentMem, Configuration.RowEndingMemory);
-            var c = commentChar.Value;
-
-            return (c, seq);
-        }
-
         internal static void CheckCanEncode(ReadOnlySpan<char> chars, Options options)
         {
             var escapedValueStartAndEnd = options.EscapedValueStartAndEnd;


### PR DESCRIPTION
Visible changes:

 - adds `IWriter<TRow>.WriteComment(ReadOnlySpan<char>)`
 - adds IAsyncWriter<TRow>.WriteCommentAsync(ReadOnlyMemory<char>, CancellationToken)`

Internal changes:

 - write comment paths no longer use strings
 - `Utils.Split` has been removed
 - a `ReadOnlySequence<char>` will no longer be allocated for multi-line comments
