### PR TITLE
Remove allocations due to sorting keys in NameLookup

### DIFF
--- a/Cesil.Benchmark/Benchmarks/Internals/NameLookupBenchmark_Create.cs
+++ b/Cesil.Benchmark/Benchmarks/Internals/NameLookupBenchmark_Create.cs
@@ -14,8 +14,8 @@ namespace Cesil.Benchmark
 
         public IEnumerable<string> NameSets => new[] { nameof(WideRow), nameof(NarrowRow<object>), "CommonEnglish" };
 
-        private List<string> Names;
-        private List<string> MissingNames;
+        private string[] Names;
+        private string[] MissingNames;
 
         private Dictionary<string, int> DictionaryLookup;
         private string[] ArrayLookup;
@@ -26,12 +26,12 @@ namespace Cesil.Benchmark
         public void Initialize()
         {
             var rand = new Random(2020_05_22);
-            Names = Benchmark.NameSet.GetNameSet(NameSet);
+            Names = Benchmark.NameSet.GetNameSet(NameSet).ToArray();
 
-            MissingNames = new List<string>();
-            while (MissingNames.Count < Names.Count)
+            var missingNamesRaw = new List<string>();
+            while (missingNamesRaw.Count < Names.Length)
             {
-                var baseName = Names[rand.Next(Names.Count)];
+                var baseName = Names[rand.Next(Names.Length)];
                 string newName;
 
                 switch (rand.Next(3))
@@ -59,8 +59,9 @@ namespace Cesil.Benchmark
 
                 if (Names.Contains(newName)) continue;
 
-                MissingNames.Add(newName);
+                missingNamesRaw.Add(newName);
             }
+            MissingNames = missingNamesRaw.ToArray();
 
             InitializeClass(nameof(Dictionary<string, int>));
             InitializeClass(nameof(System.Array));
@@ -122,7 +123,7 @@ namespace Cesil.Benchmark
         private Dictionary<string, int> DictionaryImpl()
         {
             var ret = new Dictionary<string, int>();
-            for (var i = 0; i < Names.Count; i++)
+            for (var i = 0; i < Names.Length; i++)
             {
                 ret[Names[i]] = i;
             }
@@ -149,8 +150,7 @@ namespace Cesil.Benchmark
 
         private NameLookup NameLookup_BinarySearchImpl()
         {
-            var withIx = Names.Select((n, ix) => (Name: n, Index: ix));
-            var inOrder = withIx.OrderBy(o => o.Name, StringComparer.Ordinal);
+            using var inOrder = NameLookup.OrdererNames.Create(Names, MemoryPool<char>.Shared);
 
             if (!NameLookup.TryCreateBinarySearch(inOrder, MemoryPool<char>.Shared, out var owner, out var mem))
             {
@@ -169,8 +169,7 @@ namespace Cesil.Benchmark
 
         private NameLookup NameLookup_AdaptiveRadixTrieImpl()
         {
-            var withIx = Names.Select((n, ix) => (Name: n, Index: ix));
-            var inOrder = withIx.OrderBy(o => o.Name, StringComparer.Ordinal);
+            using var inOrder = NameLookup.OrdererNames.Create(Names, MemoryPool<char>.Shared);
 
             if (!NameLookup.TryCreateAdaptiveRadixTrie(inOrder, MemoryPool<char>.Shared, out var owner, out var mem))
             {

--- a/Cesil.Benchmark/Benchmarks/Internals/NameLookupBenchmark_LookupFailure.cs
+++ b/Cesil.Benchmark/Benchmarks/Internals/NameLookupBenchmark_LookupFailure.cs
@@ -16,8 +16,8 @@ namespace Cesil.Benchmark
 
         public IEnumerable<string> NameSets => new[] { nameof(WideRow), nameof(NarrowRow<object>), "CommonEnglish" };
 
-        private List<string> Names;
-        private List<string> MissingNames;
+        private string[] Names;
+        private string[] MissingNames;
 
         private Dictionary<string, int> DictionaryLookup;
         private string[] ArrayLookup;
@@ -28,12 +28,12 @@ namespace Cesil.Benchmark
         public void Initialize()
         {
             var rand = new Random(2020_05_22);
-            Names = Benchmark.NameSet.GetNameSet(NameSet);
+            Names = Benchmark.NameSet.GetNameSet(NameSet).ToArray();
 
-            MissingNames = new List<string>();
-            while (MissingNames.Count < Names.Count)
+            var missingNamesRaw = new List<string>();
+            while (missingNamesRaw.Count < Names.Length)
             {
-                var baseName = Names[rand.Next(Names.Count)];
+                var baseName = Names[rand.Next(Names.Length)];
                 string newName;
 
                 switch (rand.Next(3))
@@ -61,8 +61,9 @@ namespace Cesil.Benchmark
 
                 if (Names.Contains(newName)) continue;
 
-                MissingNames.Add(newName);
+                missingNamesRaw.Add(newName);
             }
+            MissingNames = missingNamesRaw.ToArray();
 
             InitializeClass(nameof(Dictionary<string, int>));
             InitializeClass(nameof(System.Array));
@@ -121,7 +122,7 @@ namespace Cesil.Benchmark
             // for curiousity, what does it look like when all the keys aren't present?
             for (var iter = 0; iter < ITERS; iter++)
             {
-                for (var i = 0; i < MissingNames.Count; i++)
+                for (var i = 0; i < MissingNames.Length; i++)
                 {
                     var name = MissingNames[i];
                     DictionaryLookup.TryGetValue(name, out _);
@@ -132,7 +133,7 @@ namespace Cesil.Benchmark
         private Dictionary<string, int> DictionaryImpl()
         {
             var ret = new Dictionary<string, int>();
-            for (var i = 0; i < Names.Count; i++)
+            for (var i = 0; i < Names.Length; i++)
             {
                 ret[Names[i]] = i;
             }
@@ -147,7 +148,7 @@ namespace Cesil.Benchmark
             //   the expected case for NameLookup
             for (var iter = 0; iter < ITERS; iter++)
             {
-                for (var i = 0; i < MissingNames.Count; i++)
+                for (var i = 0; i < MissingNames.Length; i++)
                 {
                     var name = MissingNames[i];
                     System.Array.IndexOf(ArrayLookup, name);
@@ -167,7 +168,7 @@ namespace Cesil.Benchmark
             //   the expected case for NameLookup
             for (var iter = 0; iter < ITERS; iter++)
             {
-                for (var i = 0; i < MissingNames.Count; i++)
+                for (var i = 0; i < MissingNames.Length; i++)
                 {
                     var name = MissingNames[i];
                     BinarySearch.TryLookup(name, out _);
@@ -177,8 +178,7 @@ namespace Cesil.Benchmark
 
         private NameLookup NameLookup_BinarySearchImpl()
         {
-            var withIx = Names.Select((n, ix) => (Name: n, Index: ix));
-            var inOrder = withIx.OrderBy(o => o.Name, StringComparer.Ordinal);
+            using var inOrder = NameLookup.OrdererNames.Create(Names, MemoryPool<char>.Shared);
 
             if (!NameLookup.TryCreateBinarySearch(inOrder, MemoryPool<char>.Shared, out var owner, out var mem))
             {
@@ -196,7 +196,7 @@ namespace Cesil.Benchmark
             //   the expected case for NameLookup
             for (var iter = 0; iter < ITERS; iter++)
             {
-                for (var i = 0; i < MissingNames.Count; i++)
+                for (var i = 0; i < MissingNames.Length; i++)
                 {
                     var name = MissingNames[i];
                     AdaptiveRadixTrie.TryLookup(name, out _);
@@ -206,8 +206,7 @@ namespace Cesil.Benchmark
 
         private NameLookup NameLookup_AdaptiveRadixTrieImpl()
         {
-            var withIx = Names.Select((n, ix) => (Name: n, Index: ix));
-            var inOrder = withIx.OrderBy(o => o.Name, StringComparer.Ordinal);
+            using var inOrder = NameLookup.OrdererNames.Create(Names, MemoryPool<char>.Shared);
 
             if (!NameLookup.TryCreateAdaptiveRadixTrie(inOrder, MemoryPool<char>.Shared, out var owner, out var mem))
             {

--- a/Cesil/Cesil.xml
+++ b/Cesil/Cesil.xml
@@ -1783,7 +1783,6 @@
              
             we end up with:
              - count 3
-             - 
             
             
              0: 0000, 0003,     // 3 strings (each int takes 2 chars)
@@ -1799,7 +1798,43 @@
             
             The length of each string can be determined from the difference between each index, with a special case for the LAST string
               whose length can be calculated from the end of the memory.
+            </summary>
+        </member>
+        <member name="T:Cesil.NameLookup.OrdererNames">
+            <summary>
+            In order string-int key values
             
+            Data is stored like:
+             - (index of string) (value for string)
+             - (inded of string) (value for string)
+             - ...
+             - (length of string)
+             - (string data)
+             - (value for string)
+             - (length of string)
+             - (string data)
+             - (value for string)
+            
+            So, it looks like:
+             - index of string 0
+             - index of string 1
+             - index of string 2
+             - ...
+             - (length and string and value data)
+             - (length and string and value data)
+             - (length and string and value data)
+            
+            The indexes at the front are stored sorted, but everything else isn't.  That means
+              that whenever a value is inserted, the indexes at the front may move around
+              but once written none of the string data is ever moved.
+            
+            Strings are referred to by absolute indexes.  Offsets would be more efficient
+              if we resized the array, but since we pre-allocate the correct size
+              it's just extra math.
+            
+            The variable length data being at the end and _not_ being in order
+              let's the ordering algorithm swap values just by moving fixed size
+              chunks around, never having to move string data.
             </summary>
         </member>
         <member name="T:Cesil.RowConstructor">

--- a/Cesil/Common/LogHelper.cs
+++ b/Cesil/Common/LogHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Cesil
 {
@@ -22,17 +23,24 @@ namespace Cesil
         // NameLookup: log events related
 
         [Conditional(NAME_LOOKUP ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void NameLookup_OrderedNames(List<ReadOnlyMemory<char>> sortedNames, [CallerMemberName]string? caller = null)
+        internal static void NameLookup_OrderedNames(NameLookup.OrdererNames sortedNames, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
 
+            var vals = new List<string>();
+            for (var i = 0; i < sortedNames.Count; i++)
+            {
+                var name = new string(sortedNames[i].Name.Span);
+                vals.Add(name);
+            }
+
             Debug.WriteLine(
-                $"{caller}: ordered names ({string.Join(", ", sortedNames.Select(x => '"' + new string(x.Span) + '"'))})"
+                $"{caller}: ordered names ({string.Join(", ", vals.Select(x => '"' + x + '"'))})"
             );
         }
 
         [Conditional(NAME_LOOKUP ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void NameLookup_StorePrefixGroups(int depth, ushort startOfPrefixGroup, ReadOnlySpan<char> name, int prefixLen, [CallerMemberName]string? caller = null)
+        internal static void NameLookup_StorePrefixGroups(int depth, ushort startOfPrefixGroup, ReadOnlySpan<char> name, int prefixLen, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
 
@@ -42,7 +50,7 @@ namespace Cesil
         }
 
         [Conditional(NAME_LOOKUP ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void NameLookup_Indexes(int depth, ushort newFirstNamesIx, ushort newLastNamesIx, [CallerMemberName]string? caller = null)
+        internal static void NameLookup_Indexes(int depth, ushort newFirstNamesIx, ushort newLastNamesIx, [CallerMemberName] string? caller = null)
         {
             Debug.WriteLine($"{caller}: depth={depth}, start:{newFirstNamesIx}, last:{newLastNamesIx}");
         }
@@ -50,7 +58,7 @@ namespace Cesil
         // State transition log events
 
         [Conditional(STATE_TRANSITION ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void StateTransition_NewHeadersReader([CallerMemberName]string? caller = null)
+        internal static void StateTransition_NewHeadersReader([CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
 
@@ -58,7 +66,7 @@ namespace Cesil
         }
 
         [Conditional(STATE_TRANSITION ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void StateTransition_ChangeState(ReaderStateMachine.State from, char c, ReaderStateMachine.State to, ReaderStateMachine.AdvanceResult res, [CallerMemberName]string? caller = null)
+        internal static void StateTransition_ChangeState(ReaderStateMachine.State from, char c, ReaderStateMachine.State to, ReaderStateMachine.AdvanceResult res, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
 
@@ -68,21 +76,21 @@ namespace Cesil
         // TrackedMemoryPool (defined in Cesil.Tests) log events
 
         [Conditional(TRACKED_MEMORY_OWNER ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void TrackedMemoryOwner_New(int poolId, [CallerMemberName]string? caller = null)
+        internal static void TrackedMemoryOwner_New(int poolId, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
             Debug.WriteLine($"{caller}: Initializing PoolId={poolId}");
         }
 
         [Conditional(TRACKED_MEMORY_OWNER ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void TrackedMemoryOwner_Rent(int id, [CallerMemberName]string? caller = null)
+        internal static void TrackedMemoryOwner_Rent(int id, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
             Debug.WriteLine($"\t{caller}: Rented {id}");
         }
 
         [Conditional(TRACKED_MEMORY_OWNER ? DEBUG_SYMBOL : NEVER_SYMBOL)]
-        internal static void TrackedMemoryOwner_Freed(int id, [CallerMemberName]string? caller = null)
+        internal static void TrackedMemoryOwner_Freed(int id, [CallerMemberName] string? caller = null)
         {
             caller = SetCaller(caller);
             Debug.WriteLine($"\t{caller}: Freed {id}");

--- a/Cesil/Reader/Dynamic/NameLookup.Orderer.cs
+++ b/Cesil/Reader/Dynamic/NameLookup.Orderer.cs
@@ -1,0 +1,279 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using static Cesil.DisposableHelper;
+
+namespace Cesil
+{
+    // contains bits necessary for ordering 
+    //  some names and values during creation
+    //  without allocating on the heap
+    internal partial struct NameLookup
+    {
+        /// <summary>
+        /// In order string-int key values
+        /// 
+        /// Data is stored like:
+        ///  - (index of string) (value for string)
+        ///  - (inded of string) (value for string)
+        ///  - ...
+        ///  - (length of string)
+        ///  - (string data)
+        ///  - (value for string)
+        ///  - (length of string)
+        ///  - (string data)
+        ///  - (value for string)
+        /// 
+        /// So, it looks like:
+        ///  - index of string 0
+        ///  - index of string 1
+        ///  - index of string 2
+        ///  - ...
+        ///  - (length and string and value data)
+        ///  - (length and string and value data)
+        ///  - (length and string and value data)
+        /// 
+        /// The indexes at the front are stored sorted, but everything else isn't.  That means
+        ///   that whenever a value is inserted, the indexes at the front may move around
+        ///   but once written none of the string data is ever moved.
+        /// 
+        /// Strings are referred to by absolute indexes.  Offsets would be more efficient
+        ///   if we resized the array, but since we pre-allocate the correct size
+        ///   it's just extra math.
+        /// 
+        /// The variable length data being at the end and _not_ being in order
+        ///   let's the ordering algorithm swap values just by moving fixed size
+        ///   chunks around, never having to move string data.
+        /// </summary>
+        internal struct OrdererNames : ITestableDisposable
+        {
+            private const int CHARS_PER_INT = sizeof(int) / sizeof(char);
+
+            private IMemoryOwner<char> Owner;
+
+            internal readonly ReadOnlyMemory<char> Memory;
+            internal readonly int Count;
+
+            public bool IsDisposed => Owner == EmptyMemoryOwner.Singleton;
+
+            internal (ReadOnlyMemory<char> Name, int Index) this[int index]
+            {
+                get
+                {
+                    AssertNotDisposedInternal(this);
+
+                    if (index < 0 || index >= Count)
+                    {
+                        return Throw.ArgumentOutOfRangeException<(ReadOnlyMemory<char>, int)>(nameof(index), index, Count);
+                    }
+
+                    var memSpan = Memory.Span;
+
+                    var entryOffset = index * CHARS_PER_INT;
+                    var entrySliceSpan = memSpan.Slice(entryOffset, CHARS_PER_INT);
+                    var entryIntSpan = MemoryMarshal.Cast<char, int>(entrySliceSpan);
+                    var stringIndex = entryIntSpan[0];
+
+                    var stringLengthSliceSpan = memSpan.Slice(stringIndex, CHARS_PER_INT);
+                    var stringLength = MemoryMarshal.Cast<char, int>(stringLengthSliceSpan)[0];
+
+                    var stringMem = Memory.Slice(stringIndex + CHARS_PER_INT, stringLength);
+
+                    var valueSliceSpan = memSpan.Slice(stringIndex + CHARS_PER_INT + stringLength, CHARS_PER_INT);
+                    var valueIntSpan = MemoryMarshal.Cast<char, int>(valueSliceSpan);
+                    var valueIndex = valueIntSpan[0];
+
+                    return (stringMem, valueIndex);
+                }
+            }
+
+            internal OrdererNames(int count, IMemoryOwner<char> owner)
+            {
+                Count = count;
+                Owner = owner;
+                Memory = owner.Memory;
+            }
+
+            internal static OrdererNames Create(string[] names, MemoryPool<char> pool)
+            {
+                // it's REALLY easy to spend a ton of time copying
+                //      data around, so just pre-freaking allocate
+                var neededChars = 0;
+                foreach (var item in names)
+                {
+                    neededChars += CHARS_PER_INT;   // offset
+                    neededChars += CHARS_PER_INT;   // value
+                    neededChars += CHARS_PER_INT;   // string length
+                    neededChars += item.Length;     // chars
+                }
+
+                var memOwner = pool.Rent(neededChars);
+                var span = memOwner.Memory.Span;
+
+                if (span.Length < neededChars)
+                {
+                    return Throw.InvalidOperationException<OrdererNames>($"Could not order dynamic member names, names could not fit in memory acquired from MemoryPool: {pool}");
+                }
+
+                var lastOffsetIx = 0;
+                var lastStringIx = span.Length;
+
+                var ix = 0;
+                foreach (var name in names)
+                {
+                    var nameSpan = name.AsSpan();
+
+                    // insert (length) + string.Length chars
+                    var insertStringAt = lastStringIx - name.Length;
+                    insertStringAt -= 2 * CHARS_PER_INT;
+
+                    var newLastOffsetIx = lastOffsetIx + CHARS_PER_INT;
+
+                    // copy string
+                    MemoryMarshal.Cast<char, int>(span.Slice(insertStringAt, CHARS_PER_INT))[0] = name.Length;
+                    nameSpan.CopyTo(span.Slice(insertStringAt + CHARS_PER_INT, name.Length));
+                    // copy value
+                    MemoryMarshal.Cast<char, int>(span.Slice(insertStringAt + CHARS_PER_INT + name.Length, CHARS_PER_INT))[0] = ix;
+                    lastStringIx = insertStringAt;
+
+                    // binary search to find where to insert
+                    var insertEntryAtIx = FindInsertionIx(span, ix, nameSpan);
+
+                    // copy entries forward to make space
+                    if (insertEntryAtIx != ix)
+                    {
+                        var entriesToCopy = ix - insertEntryAtIx;
+
+                        var startOfEntriesToCopy = insertEntryAtIx * CHARS_PER_INT;
+                        var charsToCopy = entriesToCopy * CHARS_PER_INT;
+
+                        var toCopy = span.Slice(startOfEntriesToCopy, charsToCopy);
+
+                        var startOfCopyTo = startOfEntriesToCopy + CHARS_PER_INT;
+                        var copyTo = span.Slice(startOfCopyTo, charsToCopy);
+
+                        toCopy.CopyTo(copyTo);
+                    }
+
+                    // record entry
+                    var entrySpan = MemoryMarshal.Cast<char, int>(span.Slice(insertEntryAtIx * CHARS_PER_INT, CHARS_PER_INT));
+                    entrySpan[0] = insertStringAt;
+                    lastOffsetIx = newLastOffsetIx;
+
+                    ix++;
+                }
+
+                return new OrdererNames(ix, memOwner);
+            }
+
+            // internal for testing purposes
+            internal static int FindInsertionIx(ReadOnlySpan<char> span, int numEntries, ReadOnlySpan<char> nameSpan)
+            {
+                if (numEntries == 0)
+                {
+                    return 0;
+                }
+
+                var startOfWindowIx = 0;
+                var endOfWindowIx = numEntries - 1;
+                var curPivotIx = numEntries / 2;
+
+                while (true)
+                {
+                    var str = GetStringAtIndex(span, curPivotIx);
+
+                    // at end of loop
+                    //    cmpRes < 0 iff str < name
+                    //    cmpRes > 0 iff str > name
+                    //    cmpRes = 0 iff str == name UP TO THEIR COMMON LENGTH
+                    var cmpRes = 0;
+                    var cmpLen = Math.Min(str.Length, nameSpan.Length);
+                    for (var i = 0; i < cmpLen; i++)
+                    {
+                        var cStr = str[i];
+                        var cName = nameSpan[i];
+
+                        cmpRes = cName - cStr;
+                        if (cmpRes != 0)
+                        {
+                            break;
+                        }
+                    }
+
+                    // after this, cmp = 0 iff str == name in absolute terms
+                    if (cmpRes == 0)
+                    {
+                        cmpRes = nameSpan.Length - str.Length;
+                    }
+
+                    // adjust the window to look at
+                    if (cmpRes < 0)
+                    {
+                        // move towards the start of the window
+                        endOfWindowIx = curPivotIx - 1;
+                    }
+                    else if (cmpRes > 0)
+                    {
+                        // move towards the end of the window
+                        startOfWindowIx = curPivotIx + 1;
+                    }
+                    else
+                    {
+                        // exact match found, that's not allowed
+                        return Throw.InvalidOperationException<int>($"Two or more members with same name ({new string(nameSpan)}) encountered");
+                    }
+
+                    // have we exhausted our search?
+                    //   if so, the correct insertion point is whatever
+                    //   we just looked at if nameSpan < str
+                    //   and one after it if nameSpan > str
+                    // equivalently
+                    //    return curPivotIx iff cmpRes < 0
+                    //    return curPivotIx + 1 iff cmpRes > 0
+                    if (startOfWindowIx > endOfWindowIx)
+                    {
+                        var ret = curPivotIx;
+                        if (cmpRes > 0)
+                        {
+                            ret++;
+                        }
+
+                        return ret;
+                    }
+
+                    // pick a new pivot point
+                    //   note that you have to be really careful about this calculation
+                    //   or you have an overflow
+                    // don't mess with the math
+                    var entriesInWindow = endOfWindowIx - startOfWindowIx + 1;
+                    curPivotIx = startOfWindowIx + entriesInWindow / 2;
+                }
+            }
+
+            private static ReadOnlySpan<char> GetStringAtIndex(ReadOnlySpan<char> span, int ix)
+            {
+                var entryIx = ix * CHARS_PER_INT;
+                var index = MemoryMarshal.Cast<char, int>(span.Slice(entryIx, CHARS_PER_INT))[0];
+
+                var strLen = MemoryMarshal.Cast<char, int>(span.Slice(index, CHARS_PER_INT))[0];
+
+                var ret = span.Slice(index + CHARS_PER_INT, strLen);
+
+                return ret;
+            }
+
+            public void Dispose()
+            {
+                if (!IsDisposed)
+                {
+                    Owner.Dispose();
+                    Owner = EmptyMemoryOwner.Singleton;
+                }
+            }
+        }
+
+    }
+}

--- a/Cesil/Reader/Dynamic/NameLookup.cs
+++ b/Cesil/Reader/Dynamic/NameLookup.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Cesil.DisposableHelper;
@@ -68,7 +65,6 @@ namespace Cesil
     ///  
     /// we end up with:
     ///  - count 3
-    ///  - 
     /// 
     /// 
     ///  0: 0000, 0003,     // 3 strings (each int takes 2 chars)
@@ -84,9 +80,8 @@ namespace Cesil
     /// 
     /// The length of each string can be determined from the difference between each index, with a special case for the LAST string
     ///   whose length can be calculated from the end of the memory.
-    /// 
     /// </summary>
-    internal struct NameLookup : ITestableDisposable
+    internal partial struct NameLookup : ITestableDisposable
     {
         // internal for testing purposes
         internal enum Algorithm : byte
@@ -432,18 +427,22 @@ processPrefixGroup:
             }
         }
 
-        internal static NameLookup Create(IEnumerable<string> names, MemoryPool<char> memoryPool)
+        internal static NameLookup Create(string[] names, MemoryPool<char> memoryPool)
         {
-            // todo: can we do this in a less allocate-y way? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/4)
-            // sort 'em, so we can more easily find common prefixes
-            var inOrder = names.Select((n, ix) => (Name: n, Index: ix)).OrderBy(t => t.Name, StringComparer.Ordinal);
+            using var ordered = OrdererNames.Create(names, memoryPool);
 
-            if (TryCreateAdaptiveRadixTrie(inOrder, memoryPool, out var trieOwner, out var trieMem))
+            return CreateInner(ordered, memoryPool);
+        }
+
+        // internal for testing purposes
+        internal static NameLookup CreateInner(OrdererNames ordered, MemoryPool<char> memoryPool)
+        {
+            if (TryCreateAdaptiveRadixTrie(ordered, memoryPool, out var trieOwner, out var trieMem))
             {
                 return new NameLookup(Algorithm.AdaptiveRadixTrie, trieOwner, trieMem);
             }
 
-            if (TryCreateBinarySearch(inOrder, memoryPool, out var binaryTreeOwner, out var binaryTreeMem))
+            if (TryCreateBinarySearch(ordered, memoryPool, out var binaryTreeOwner, out var binaryTreeMem))
             {
                 return new NameLookup(Algorithm.BinarySearch, binaryTreeOwner, binaryTreeMem);
             }
@@ -452,24 +451,17 @@ processPrefixGroup:
         }
 
         // internal for testing purposes
-        internal static bool TryCreateBinarySearch(IOrderedEnumerable<(string Name, int Index)> inOrder, MemoryPool<char> memoryPool, out IMemoryOwner<char> memOwner, out ReadOnlyMemory<char> mem)
+        internal static bool TryCreateBinarySearch(OrdererNames inOrder, MemoryPool<char> memoryPool, out IMemoryOwner<char> memOwner, out ReadOnlyMemory<char> mem)
         {
-            // todo: don't love allocating here? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/4)
-            var sortedNames = new List<ReadOnlyMemory<char>>();
-            var sortedNamesValues = new List<int>();
-
             var neededChars = CHARS_PER_INT;    // start at 1 int, because we need a count
 
-            foreach (var t in inOrder)
+            for (var i = 0; i < inOrder.Count; i++)
             {
-                var tMem = t.Name.AsMemory();
+                var (tMem, _) = inOrder[i];
 
                 neededChars += CHARS_PER_INT;   // 1 for the index into the string
                 neededChars += CHARS_PER_INT;   // 1 for the value
                 neededChars += tMem.Length;     // then the string itself
-
-                sortedNames.Add(tMem);
-                sortedNamesValues.Add(t.Index);
             }
 
             var writeableMemOwner = memoryPool.Rent(neededChars);
@@ -491,13 +483,12 @@ processPrefixGroup:
             var backPtr = charSpan.Length;
 
             // store the count of names
-            intSpan[frontPtr] = sortedNames.Count;
+            intSpan[frontPtr] = inOrder.Count;
             frontPtr++;
 
-            for (var i = 0; i < sortedNames.Count; i++)
+            for (var i = 0; i < inOrder.Count; i++)
             {
-                var name = sortedNames[i];
-                var value = sortedNamesValues[i];
+                var (name, value) = inOrder[i];
 
                 // copy the string to the furthest unused chunk of charSpan
                 var startOfNameIx = backPtr - name.Length;
@@ -520,44 +511,34 @@ processPrefixGroup:
             return true;
         }
 
-        internal static bool TryCreateAdaptiveRadixTrie(IOrderedEnumerable<(string Name, int Index)> inOrder, MemoryPool<char> memoryPool, out IMemoryOwner<char> memOwner, out ReadOnlyMemory<char> mem)
+        internal static bool TryCreateAdaptiveRadixTrie(OrdererNames inOrder, MemoryPool<char> memoryPool, out IMemoryOwner<char> memOwner, out ReadOnlyMemory<char> mem)
         {
-            // todo: don't love allocating here? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/4)
-            var sortedNames = new List<ReadOnlyMemory<char>>();
-            var sortedNamesValues = new List<ushort>();
-
-            foreach (var t in inOrder)
+            // check to see if any of the values are too large
+            for (var i = 0; i < inOrder.Count; i++)
             {
-                sortedNames.Add(t.Name.AsMemory());
-
-                var index = t.Index;
-
-                // this is the largest _VALUE_ we can store
-                if (index > short.MaxValue)
+                var (_, index) = inOrder[i];
+                if (index > ushort.MaxValue)
                 {
                     memOwner = EmptyMemoryOwner.Singleton;
                     mem = ReadOnlyMemory<char>.Empty;
                     return false;
                 }
-
-                var asUshort = (ushort)index;
-
-                sortedNamesValues.Add(asUshort);
             }
 
-            if (sortedNames.Count > ushort.MaxValue)
+            // is the total count of keys too large?
+            if (inOrder.Count > ushort.MaxValue)
             {
                 memOwner = EmptyMemoryOwner.Singleton;
                 mem = ReadOnlyMemory<char>.Empty;
                 return false;
             }
 
-            LogHelper.NameLookup_OrderedNames(sortedNames);
-            
-            ushort startIx = 0;
-            ushort lastIx = (ushort)(sortedNames.Count - 1);    // we know this will fix because we check the site of sortedNames above
+            LogHelper.NameLookup_OrderedNames(inOrder);
 
-            var neededMemory = CalculateNeededMemoryAdaptivePrefixTrie(sortedNames, startIx, lastIx, 0);
+            ushort startIx = 0;
+            ushort lastIx = (ushort)(inOrder.Count - 1);    // we know this will fix because we check the site of sortedNames above
+
+            var neededMemory = CalculateNeededMemoryAdaptivePrefixTrie(inOrder, startIx, lastIx, 0);
 
             var writeableMemOwner = memoryPool.Rent(neededMemory);
             var writeableMem = writeableMemOwner.Memory;
@@ -574,7 +555,7 @@ processPrefixGroup:
 
             var span = writeableMem.Span;
 
-            if (!StorePrefixGroups(0, sortedNames, startIx, lastIx, sortedNamesValues, span, 0, out _))
+            if (!StorePrefixGroups(0, inOrder, startIx, lastIx, span, 0, out _))
             {
                 writeableMemOwner.Dispose();
                 memOwner = EmptyMemoryOwner.Singleton;
@@ -596,12 +577,9 @@ processPrefixGroup:
                 //   [firstNamesIx, lastNamesIx] on each call
                 // this works because names is sorted, so
                 //   we always process contiguous chunks
-                List<ReadOnlyMemory<char>> names,
+                OrdererNames names,
                 ushort firstNamesIx,
                 ushort lastNamesIx,
-                // values is boxed by the same indexes
-                //    as names
-                List<ushort> values,
                 // groupStartSpan is the origin point for writing
                 //   in this particular call.
                 // it is advanced prior to each recursion, so
@@ -642,7 +620,7 @@ processPrefixGroup:
                     var startOfPrefixGroup = firstNamesIx;
                     while (startOfPrefixGroup <= lastNamesIx)
                     {
-                        var name = names[startOfPrefixGroup].Span;
+                        var name = names[startOfPrefixGroup].Name.Span;
 
                         // increment the number of prefixes we've stored
                         //
@@ -722,7 +700,7 @@ processPrefixGroup:
                             // store the next prefix groups into the buffer, and then note that we've advanced that far
                             //   into the span
                             var newIgnoreCharCount = ignoreCharCount + prefixLen;
-                            if (!StorePrefixGroups(depth + 1, names, newFirstNamesIx, newLastNamesIx, values, nextGroupStartSpan, newIgnoreCharCount, out var sizeOfNextPrefixGroup))
+                            if (!StorePrefixGroups(depth + 1, names, newFirstNamesIx, newLastNamesIx, nextGroupStartSpan, newIgnoreCharCount, out var sizeOfNextPrefixGroup))
                             {
                                 curOffset = -1;
                                 return false;
@@ -735,7 +713,7 @@ processPrefixGroup:
                             //   so rather than actually store a 1 entry group
                             //   overload the space we'd store the offset
                             //   to instead store the final value.
-                            var value = values[newFirstNamesIx];
+                            var value = (ushort)names[newFirstNamesIx].Index;
                             var valueChar = ToValue(value);
                             groupStartSpan[groupPtr] = valueChar;
                             groupPtr++;
@@ -860,7 +838,7 @@ processPrefixGroup:
             //   [firstNamesIx, lastNamesIx] on each call
             // this works because names is sorted, so
             //   we always process contiguous chunks
-            List<ReadOnlyMemory<char>> names,
+            OrdererNames names,
             ushort firstNamesIx,
             ushort lastNamesIx,
             // rather than re-allocate names with prefixes removed
@@ -915,7 +893,7 @@ processPrefixGroup:
             //   >= first).
             // this works because names is sorted, so
             //   we always process contiguous chunks
-            List<ReadOnlyMemory<char>> names,
+            OrdererNames names,
             ushort lastNamesIx,
             ushort nameIx,
             // rather than re-allocate names with prefixes removed
@@ -931,7 +909,7 @@ processPrefixGroup:
         {
             lastIndexInPrefixGroup = nameIx;
 
-            var name = names[nameIx].Span;
+            var name = names[nameIx].Name.Span;
 
             name = name.Slice(ignoreCharCount);
 
@@ -944,7 +922,7 @@ processPrefixGroup:
 
             for (ushort j = (ushort)(nameIx + 1); j <= lastNamesIx; j++)
             {
-                var otherName = names[j].Span.Slice(ignoreCharCount);
+                var otherName = names[j].Name.Span.Slice(ignoreCharCount);
                 if (otherName[0] != firstChar)
                 {
                     break;


### PR DESCRIPTION
Visible changes:

 - The `MemoryPool<char>` on an `Options` will see more use during construction of `NameLookup` when deserializing dynamic rows (first row read only)

Internal changes:

 - Closes #4 - there are no more mandatory heap allocations when creating a `NameLookup`
 - `NameLookup` construction now expects the same collection to provide names and indexes, rather than the two used before
 - `NameLookup` now expects column names to be stored in an array, whereas before it could run over any `IEnumerable<string>`