### PR TITLE
Removes allocations from formatting `[Flags]` enum values

### DIFF
--- a/Cesil.Tests/DefaultTypeDescriberTests.cs
+++ b/Cesil.Tests/DefaultTypeDescriberTests.cs
@@ -1323,20 +1323,7 @@ namespace Cesil.Tests
         [Fact]
         public async Task Formatter_GetDefault()
         {
-            string BufferToString(ReadOnlySequence<byte> buff)
-            {
-                var bytes = new List<byte>();
-                foreach (var b in buff)
-                {
-                    bytes.AddRange(b.ToArray());
-                }
-
-                var byteArray = bytes.ToArray();
-                var byteSpan = new Span<byte>(byteArray);
-                var charSpan = MemoryMarshal.Cast<byte, char>(byteSpan);
-
-                return new string(charSpan);
-            }
+            var ctx = WriteContext.WritingColumn(Options.Default, 0, ColumnIdentifier.Create(0), null);
 
             // string
             {
@@ -1345,7 +1332,7 @@ namespace Cesil.Tests
                 var reader = pipe.Reader;
 
                 var mtd = Formatter.GetDefault(typeof(string).GetTypeInfo()).Method.Value;
-                var res = mtd.Invoke(null, new object[] { "foo", default(WriteContext), writer });
+                var res = mtd.Invoke(null, new object[] { "foo", ctx, writer });
                 var resBool = (bool)res;
                 Assert.True(resBool);
 
@@ -1372,7 +1359,7 @@ namespace Cesil.Tests
                 var f = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
                 {
-                    var res = mtd.Invoke(null, new object[] { a, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { a, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1384,7 +1371,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { b, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { b, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1396,7 +1383,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { c, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { c, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1408,7 +1395,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { d, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { d, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1420,7 +1407,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { e, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { e, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1432,7 +1419,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1460,7 +1447,7 @@ namespace Cesil.Tests
                 var f = new Uri("https://local.bar:12345/foo?p#e", UriKind.RelativeOrAbsolute);
 
                 {
-                    var res = mtd.Invoke(null, new object[] { a, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { a, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1472,7 +1459,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { b, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { b, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1484,7 +1471,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { c, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { c, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1496,7 +1483,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { d, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { d, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1508,7 +1495,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { e, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { e, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1520,7 +1507,7 @@ namespace Cesil.Tests
                 }
 
                 {
-                    var res = mtd.Invoke(null, new object[] { f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1542,7 +1529,7 @@ namespace Cesil.Tests
 
                 // Bar
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestEnum.Bar, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestEnum.Bar, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1555,7 +1542,7 @@ namespace Cesil.Tests
 
                 // Foo
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestEnum.Foo, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestEnum.Foo, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1568,7 +1555,7 @@ namespace Cesil.Tests
 
                 // None
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestEnum.None, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestEnum.None, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1581,7 +1568,7 @@ namespace Cesil.Tests
 
                 // bad value
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum)int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum)int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.False(resBool);
                 }
@@ -1597,7 +1584,7 @@ namespace Cesil.Tests
 
                 // First
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.First, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.First, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1610,7 +1597,7 @@ namespace Cesil.Tests
 
                 // Multi
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.Multi, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.Multi, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1623,7 +1610,7 @@ namespace Cesil.Tests
 
                 // First | Fourth
                 {
-                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.First | _TestFlagsEnum.Fourth, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { _TestFlagsEnum.First | _TestFlagsEnum.Fourth, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1636,7 +1623,7 @@ namespace Cesil.Tests
 
                 // bad value
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum)int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum)int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.False(resBool);
                 }
@@ -1652,7 +1639,7 @@ namespace Cesil.Tests
 
                 // value
                 {
-                    var res = mtd.Invoke(null, new object[] { 'D', default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 'D', ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1674,7 +1661,7 @@ namespace Cesil.Tests
 
                 // true
                 {
-                    var res = mtd.Invoke(null, new object[] { true, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { true, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1687,7 +1674,7 @@ namespace Cesil.Tests
 
                 // false
                 {
-                    var res = mtd.Invoke(null, new object[] { false, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { false, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1709,7 +1696,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (byte)123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (byte)123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1731,7 +1718,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (sbyte)123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (sbyte)123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1744,7 +1731,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (sbyte)-123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (sbyte)-123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1766,7 +1753,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { short.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { short.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1779,7 +1766,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { short.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { short.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1801,7 +1788,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { ushort.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { ushort.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1823,7 +1810,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1836,7 +1823,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { int.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { int.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1858,7 +1845,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { uint.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { uint.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1880,7 +1867,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { long.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { long.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1893,7 +1880,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { long.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { long.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1915,7 +1902,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { ulong.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { ulong.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1937,7 +1924,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { 12.34f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 12.34f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1950,7 +1937,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { -12.34f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { -12.34f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1972,7 +1959,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { 12.34, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 12.34, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1985,7 +1972,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { -12.34, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { -12.34, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -1998,7 +1985,7 @@ namespace Cesil.Tests
 
                 // very long
                 {
-                    var res = mtd.Invoke(null, new object[] { 0.84551240822557006, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 0.84551240822557006, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2020,7 +2007,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { 12.34m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 12.34m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2033,7 +2020,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { -12.34m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { -12.34m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2046,7 +2033,7 @@ namespace Cesil.Tests
 
                 // large
                 {
-                    var res = mtd.Invoke(null, new object[] { 79_228_162_514_264_337_593_543_950_335m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 79_228_162_514_264_337_593_543_950_335m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2068,7 +2055,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { DateTime.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { DateTime.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2081,7 +2068,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { DateTime.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { DateTime.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2103,7 +2090,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { DateTimeOffset.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { DateTimeOffset.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2116,7 +2103,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { DateTimeOffset.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { DateTimeOffset.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2138,7 +2125,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { TimeSpan.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { TimeSpan.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2151,7 +2138,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { TimeSpan.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { TimeSpan.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2175,7 +2162,7 @@ namespace Cesil.Tests
                 {
                     var i = new Index(15, false);
 
-                    var res = mtd.Invoke(null, new object[] { i, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { i, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2190,7 +2177,7 @@ namespace Cesil.Tests
                 {
                     var i = new Index(22, true);
 
-                    var res = mtd.Invoke(null, new object[] { i, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { i, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2214,7 +2201,7 @@ namespace Cesil.Tests
                 {
                     var r = ..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2229,7 +2216,7 @@ namespace Cesil.Tests
                 {
                     var r = 3..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2244,7 +2231,7 @@ namespace Cesil.Tests
                 {
                     var r = ^3..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2259,7 +2246,7 @@ namespace Cesil.Tests
                 {
                     var r = ..3;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2274,7 +2261,7 @@ namespace Cesil.Tests
                 {
                     var r = ..^3;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2289,7 +2276,7 @@ namespace Cesil.Tests
                 {
                     var r = 1..4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2304,7 +2291,7 @@ namespace Cesil.Tests
                 {
                     var r = ^1..4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2319,7 +2306,7 @@ namespace Cesil.Tests
                 {
                     var r = 1..^4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2334,7 +2321,7 @@ namespace Cesil.Tests
                 {
                     var r = ^1..^4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2345,12 +2332,9 @@ namespace Cesil.Tests
                     reader.AdvanceTo(buff.Buffer.End);
                 }
             }
-        }
 
-        [Fact]
-        public async Task Formatter_GetDefault_Nullable()
-        {
-            string BufferToString(ReadOnlySequence<byte> buff)
+
+            static string BufferToString(ReadOnlySequence<byte> buff)
             {
                 var bytes = new List<byte>();
                 foreach (var b in buff)
@@ -2365,6 +2349,13 @@ namespace Cesil.Tests
                 return new string(charSpan);
             }
 
+        }
+
+        [Fact]
+        public async Task Formatter_GetDefault_Nullable()
+        {
+            var ctx = WriteContext.WritingColumn(Options.Default, 0, ColumnIdentifier.Create(0), null);
+
             // enum?
             {
                 var pipe = new Pipe();
@@ -2375,7 +2366,7 @@ namespace Cesil.Tests
 
                 // Bar
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.Bar, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.Bar, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2388,7 +2379,7 @@ namespace Cesil.Tests
 
                 // Foo
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.Foo, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.Foo, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2401,7 +2392,7 @@ namespace Cesil.Tests
 
                 // None
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.None, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)_TestEnum.None, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2414,7 +2405,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2425,7 +2416,7 @@ namespace Cesil.Tests
 
                 // bad value
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestEnum?)int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.False(resBool);
                 }
@@ -2441,7 +2432,7 @@ namespace Cesil.Tests
 
                 // First
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.First, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.First, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2454,7 +2445,7 @@ namespace Cesil.Tests
 
                 // Multi
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.Multi, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.Multi, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2467,7 +2458,7 @@ namespace Cesil.Tests
 
                 // First | Fourth
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.First | _TestFlagsEnum.Fourth, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)_TestFlagsEnum.First | _TestFlagsEnum.Fourth, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2480,7 +2471,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2491,7 +2482,7 @@ namespace Cesil.Tests
 
                 // bad value
                 {
-                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum)int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (_TestFlagsEnum)int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.False(resBool);
                 }
@@ -2507,7 +2498,7 @@ namespace Cesil.Tests
 
                 // value
                 {
-                    var res = mtd.Invoke(null, new object[] { (char?)'D', default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (char?)'D', ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2520,7 +2511,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (char?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (char?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2540,7 +2531,7 @@ namespace Cesil.Tests
 
                 // true
                 {
-                    var res = mtd.Invoke(null, new object[] { (bool?)true, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (bool?)true, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2553,7 +2544,7 @@ namespace Cesil.Tests
 
                 // false
                 {
-                    var res = mtd.Invoke(null, new object[] { (bool?)false, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (bool?)false, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2566,7 +2557,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (bool?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (bool?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2586,7 +2577,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (byte?)123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (byte?)123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2599,7 +2590,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (byte?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (byte?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2619,7 +2610,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (sbyte?)123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (sbyte?)123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2632,7 +2623,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (sbyte?)-123, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (sbyte?)-123, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2645,7 +2636,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (sbyte?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (sbyte?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2665,7 +2656,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (short?)short.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (short?)short.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2678,7 +2669,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (short?)short.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (short?)short.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2691,7 +2682,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (short?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (short?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2711,7 +2702,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (ushort?)ushort.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (ushort?)ushort.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2724,7 +2715,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (ushort?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (ushort?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2744,7 +2735,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (int?)int.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (int?)int.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2757,7 +2748,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (int?)int.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (int?)int.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2770,7 +2761,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (int?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (int?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2790,7 +2781,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (uint?)uint.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (uint?)uint.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2803,7 +2794,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (uint?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (uint?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2823,7 +2814,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (long?)long.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (long?)long.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2836,7 +2827,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (long?)long.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (long?)long.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2849,7 +2840,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (long?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (long?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2869,7 +2860,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (ulong?)ulong.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (ulong?)ulong.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2882,7 +2873,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (ulong?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (ulong?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2902,7 +2893,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (float?)12.34f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (float?)12.34f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2915,7 +2906,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (float?)-12.34f, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (float?)-12.34f, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2928,7 +2919,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (float?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (float?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2948,7 +2939,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (double?)12.34, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (double?)12.34, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2961,7 +2952,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (double?)-12.34, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (double?)-12.34, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2974,7 +2965,7 @@ namespace Cesil.Tests
 
                 // very long
                 {
-                    var res = mtd.Invoke(null, new object[] { 0.84551240822557006, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { 0.84551240822557006, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -2987,7 +2978,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (double?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (double?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3008,7 +2999,7 @@ namespace Cesil.Tests
 
                 // positive
                 {
-                    var res = mtd.Invoke(null, new object[] { (decimal?)12.34m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (decimal?)12.34m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3021,7 +3012,7 @@ namespace Cesil.Tests
 
                 // negative
                 {
-                    var res = mtd.Invoke(null, new object[] { (decimal?)-12.34m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (decimal?)-12.34m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3034,7 +3025,7 @@ namespace Cesil.Tests
 
                 // large
                 {
-                    var res = mtd.Invoke(null, new object[] { (decimal?)79_228_162_514_264_337_593_543_950_335m, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (decimal?)79_228_162_514_264_337_593_543_950_335m, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3047,7 +3038,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (decimal?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (decimal?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3067,7 +3058,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTime?)DateTime.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTime?)DateTime.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3080,7 +3071,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTime?)DateTime.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTime?)DateTime.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3093,7 +3084,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTime?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTime?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3113,7 +3104,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)DateTimeOffset.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)DateTimeOffset.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3126,7 +3117,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)DateTimeOffset.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)DateTimeOffset.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3139,7 +3130,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (DateTimeOffset?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3159,7 +3150,7 @@ namespace Cesil.Tests
 
                 // max
                 {
-                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)TimeSpan.MaxValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)TimeSpan.MaxValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3172,7 +3163,7 @@ namespace Cesil.Tests
 
                 // min
                 {
-                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)TimeSpan.MinValue, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)TimeSpan.MinValue, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3185,7 +3176,7 @@ namespace Cesil.Tests
 
                 // null
                 {
-                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)null, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { (TimeSpan?)null, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3207,7 +3198,7 @@ namespace Cesil.Tests
                 {
                     Index? i = new Index(15, false);
 
-                    var res = mtd.Invoke(null, new object[] { i, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { i, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3222,7 +3213,7 @@ namespace Cesil.Tests
                 {
                     Index? i = new Index(22, true);
 
-                    var res = mtd.Invoke(null, new object[] { i, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { i, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3238,7 +3229,7 @@ namespace Cesil.Tests
                 {
                     Index? i = null;
 
-                    var res = mtd.Invoke(null, new object[] { i, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { i, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3260,7 +3251,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3275,7 +3266,7 @@ namespace Cesil.Tests
                 {
                     Range? r = 3..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3290,7 +3281,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ^3..;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3305,7 +3296,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ..3;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3320,7 +3311,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ..^3;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3335,7 +3326,7 @@ namespace Cesil.Tests
                 {
                     Range? r = 1..4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3350,7 +3341,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ^1..4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3365,7 +3356,7 @@ namespace Cesil.Tests
                 {
                     Range? r = 1..^4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3380,7 +3371,7 @@ namespace Cesil.Tests
                 {
                     Range? r = ^1..^4;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3396,7 +3387,7 @@ namespace Cesil.Tests
                 {
                     Range? r = null;
 
-                    var res = mtd.Invoke(null, new object[] { r, default(WriteContext), writer });
+                    var res = mtd.Invoke(null, new object[] { r, ctx, writer });
                     var resBool = (bool)res;
                     Assert.True(resBool);
 
@@ -3404,6 +3395,21 @@ namespace Cesil.Tests
 
                     Assert.False(reader.TryRead(out _));
                 }
+            }
+
+            static string BufferToString(ReadOnlySequence<byte> buff)
+            {
+                var bytes = new List<byte>();
+                foreach (var b in buff)
+                {
+                    bytes.AddRange(b.ToArray());
+                }
+
+                var byteArray = bytes.ToArray();
+                var byteSpan = new Span<byte>(byteArray);
+                var charSpan = MemoryMarshal.Cast<byte, char>(byteSpan);
+
+                return new string(charSpan);
             }
         }
 
@@ -3696,9 +3702,11 @@ namespace Cesil.Tests
 
             static void Try<T>(T def = default)
             {
+                var ctx = WriteContext.WritingColumn(Options.Default, 0, ColumnIdentifier.Create(0), null);
+
                 var mtd = Formatter.GetDefault(typeof(T).GetTypeInfo()).Method.Value;
 
-                var res = (bool)mtd.Invoke(null, new object[] { def, default(WriteContext), _Formatter_InsufficientMemoryDoesntThrow.Singleton });
+                var res = (bool)mtd.Invoke(null, new object[] { def, ctx, _Formatter_InsufficientMemoryDoesntThrow.Singleton });
 
                 Assert.False(res);
             }

--- a/Cesil.Tests/UtilsTests.cs
+++ b/Cesil.Tests/UtilsTests.cs
@@ -1205,5 +1205,130 @@ namespace Cesil.Tests
             var res = forType.GetTypeInfo().IsFlagsEnum();
             Assert.Equal(expected, res);
         }
+
+        private enum _EnumToULong_Byte : byte { A = 0, B = byte.MaxValue }
+        private enum _EnumToULong_SByte : sbyte { A = 0, B = sbyte.MinValue }
+        private enum _EnumToULong_Short : short { A = 0, B = short.MinValue }
+        private enum _EnumToULong_UShort : ushort { A = 0, B = ushort.MaxValue }
+        private enum _EnumToULong_Int : int { A = 0, B = int.MinValue }
+        private enum _EnumToULong_UInt : uint { A = 0, B = uint.MaxValue }
+        private enum _EnumToULong_Long : long { A = 0, B = long.MinValue }
+        private enum _EnumToULong_ULong : ulong { A = 0, B = ulong.MaxValue }
+
+        [Fact]
+        public void EnumToULong()
+        {
+            // byte
+            Check(_EnumToULong_Byte.A, (byte)_EnumToULong_Byte.A);
+            Check(_EnumToULong_Byte.B, (byte)_EnumToULong_Byte.B);
+            Check((_EnumToULong_Byte)100, 100);
+
+            // sbyte
+            Check(_EnumToULong_SByte.A, (ulong)(sbyte)_EnumToULong_SByte.A);
+            Check(_EnumToULong_SByte.B, unchecked((ulong)(sbyte)_EnumToULong_SByte.B));
+            Check((_EnumToULong_SByte)(-100), unchecked((ulong)-100));
+
+            // short
+            Check(_EnumToULong_Short.A, (ulong)(short)_EnumToULong_Short.A);
+            Check(_EnumToULong_Short.B, unchecked((ulong)(short)_EnumToULong_Short.B));
+            Check((_EnumToULong_Short)100, (ulong)(short)100);
+
+            // ushort
+            Check(_EnumToULong_UShort.A, (ushort)_EnumToULong_UShort.A);
+            Check(_EnumToULong_UShort.B, (ushort)_EnumToULong_UShort.B);
+            Check((_EnumToULong_UShort)100, 100);
+
+            // int
+            Check(_EnumToULong_Int.A, (int)_EnumToULong_Int.A);
+            Check(_EnumToULong_Int.B, unchecked((ulong)(int)_EnumToULong_Int.B));
+            Check((_EnumToULong_Int)100, 100);
+
+            // uint
+            Check(_EnumToULong_UInt.A, (uint)_EnumToULong_UInt.A);
+            Check(_EnumToULong_UInt.B, (uint)_EnumToULong_UInt.B);
+            Check((_EnumToULong_UInt)100, 100);
+
+            // long
+            Check(_EnumToULong_Long.A, (long)_EnumToULong_Long.A);
+            Check(_EnumToULong_Long.B, unchecked((ulong)(long)_EnumToULong_Long.B));
+            Check((_EnumToULong_Long)(-100), unchecked((ulong)-100));
+
+            // ulong
+            Check(_EnumToULong_ULong.A, (ulong)_EnumToULong_ULong.A);
+            Check(_EnumToULong_ULong.B, (ulong)_EnumToULong_ULong.B);
+            Check((_EnumToULong_ULong)100, 100);
+
+            // test that Utils produces the right value
+            static void Check<T>(T val, ulong expected)
+                where T: struct, Enum
+            {
+                var res = Utils.EnumToULong<T>(val);
+                Assert.Equal(expected, res);
+            }
+        }
+
+        [Flags]
+        private enum _TryFormatFlagsEnum : ulong { A = 1, B = 2, C = 4, D = 8, E = 1UL << 63 };
+        [Flags]
+        private enum _TryFormatFlagsEnum_WithZero : ulong { Z = 0, A = 1, B = 2, C = 4, D = 8, E = 1UL << 63 };
+
+        [Fact]
+        public void TryFormatFlagsEnum()
+        {
+            var namesTryFormatFlagsEnum = Enum.GetNames(typeof(_TryFormatFlagsEnum));
+            var valuesTryFormatFlagsEnum = Enum.GetValues(typeof(_TryFormatFlagsEnum)).Cast<ulong>().ToArray();
+
+            var namesTryFormatFlagsEnumWithZero = Enum.GetNames(typeof(_TryFormatFlagsEnum_WithZero));
+            var valuesTryFormatFlagsEnumWithZero = Enum.GetValues(typeof(_TryFormatFlagsEnum_WithZero)).Cast<ulong>().ToArray();
+
+            // no zero
+            Test(_TryFormatFlagsEnum.A, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, true);
+            Test(_TryFormatFlagsEnum.A | _TryFormatFlagsEnum.B, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, true);
+            Test(_TryFormatFlagsEnum.B | _TryFormatFlagsEnum.E, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, true);
+            Test(_TryFormatFlagsEnum.A | _TryFormatFlagsEnum.B | _TryFormatFlagsEnum.C | _TryFormatFlagsEnum.D | _TryFormatFlagsEnum.E, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, true);
+            Test((_TryFormatFlagsEnum)17, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, false);
+            Test((_TryFormatFlagsEnum)0, namesTryFormatFlagsEnum, valuesTryFormatFlagsEnum, false);
+
+            // with zero
+            Test(_TryFormatFlagsEnum_WithZero.A, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, true);
+            Test(_TryFormatFlagsEnum_WithZero.A | _TryFormatFlagsEnum_WithZero.B, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, true);
+            Test(_TryFormatFlagsEnum_WithZero.B | _TryFormatFlagsEnum_WithZero.E, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, true);
+            Test(_TryFormatFlagsEnum_WithZero.A | _TryFormatFlagsEnum_WithZero.B | _TryFormatFlagsEnum_WithZero.C | _TryFormatFlagsEnum_WithZero.D | _TryFormatFlagsEnum_WithZero.E, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, true);
+            Test((_TryFormatFlagsEnum_WithZero)17, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, false);
+            Test(_TryFormatFlagsEnum_WithZero.Z, namesTryFormatFlagsEnumWithZero, valuesTryFormatFlagsEnumWithZero, true);
+
+            // DRY up the test a bit
+            static void Test<T>(T enumValue, string[] names, ulong[] values, bool expectedBool)
+                where T: struct, Enum
+            {
+                var expectedText = enumValue.ToString();
+                Span<char> span = default;
+
+                tryAgain:
+                var res = Utils.TryFormatFlagsEnum(enumValue, names, values, span);
+                if (res == 0)
+                {
+                    // malformed!
+                    Assert.False(expectedBool);
+                }
+                else if (res > 0)
+                {
+                    // it fit!
+                    
+                    var actualText = new string(span);
+                    Assert.Equal(expectedText, actualText);
+                }
+                else
+                {
+                    // didn't fit, did it ask for the right size?
+                    var neededLength = -res;
+                    Assert.Equal(expectedText.Length, neededLength);
+
+                    // make the span slightly bigger!
+                    span = new char[span.Length + 1].AsSpan();
+                    goto tryAgain;
+                }
+            }
+        }
     }
 }

--- a/Cesil/Cesil.xml
+++ b/Cesil/Cesil.xml
@@ -45,6 +45,17 @@
               store (1 int + the char data).
             </summary>
         </member>
+        <member name="M:Cesil.Utils.TryFormatFlagsEnum``1(``0,System.String[],System.UInt64[],System.Span{System.Char})">
+            <summary>
+            This is _like_ calling ToString(), but it doesn't allow values
+            that aren't actually declared on the enum.
+            
+            Since copyInto might not be big enough, can return the following values:
+             * 0, if flagsEnum was invalid
+             * greater than 0, length of the value that did fit into copyInto
+             * less than 0, the negated length of a value that didn't fit into copyInto
+            </summary>
+        </member>
         <member name="M:Cesil.BoundConfigurationBase`1.#ctor(System.Buffers.MemoryPool{System.Char},System.Buffers.MemoryPool{Cesil.DynamicCellValue})">
             <summary>
             For some testing scenarios.

--- a/Cesil/Writer/MaxSizedBufferWriter.cs
+++ b/Cesil/Writer/MaxSizedBufferWriter.cs
@@ -77,6 +77,10 @@ namespace Cesil
             {
                 SizeHint = Math.Min(DEFAULT_STAGING_SIZE, memoryPool.MaxBufferSize);
             }
+            else
+            {
+                SizeHint = sizeHint.Value;
+            }
 
             Head = Tail = Node.EmptyNode;
             HasNodes = false;


### PR DESCRIPTION
Removes allocations from formatting `[Flags]` enum values, closes #8.

### Visible changes

 - There are no client visible changes

### Internal changes

 - New method on `Utils`, [`EnumToULong<T>`](https://github.com/kevin-montrose/Cesil/compare/vNext...issue-8/enum-formatting-allocations?expand=1#diff-51c0b1a1fa14bd48d361f86332be01cfR1058) and [`TryFormatFlagsEnum<T>`](https://github.com/kevin-montrose/Cesil/compare/vNext...issue-8/enum-formatting-allocations?expand=1#diff-51c0b1a1fa14bd48d361f86332be01cfR1117)
 - It can now take multiple "passes" to format a `[Flags]` enum, though hopefully a single pass is common
