### PR TITLE
Removes mandatory allocations from parsing enums

### DIFF
--- a/Cesil.Tests/DefaultTypeDescriberTests.cs
+++ b/Cesil.Tests/DefaultTypeDescriberTests.cs
@@ -303,7 +303,10 @@ namespace Cesil.Tests
                 Assert.True(del(_TestEnum.Bar.ToString(), default, out var v3));
                 Assert.Equal(_TestEnum.Bar, v3);
 
-                Assert.False(del("foo", default, out _));
+                Assert.True(del("foo", default, out var v4));
+                Assert.Equal(_TestEnum.Foo, v4);
+                
+                Assert.False(del("Fizz", default, out _));
 
                 Assert.False(del("123", default, out _));
             }
@@ -325,6 +328,9 @@ namespace Cesil.Tests
                 Assert.Equal((_TestFlagsEnum.First | _TestFlagsEnum.Second), v3);
 
                 Assert.False(del("foo", default, out _));
+
+                Assert.True(del("first", default, out var v4));
+                Assert.Equal(_TestFlagsEnum.First, v4);
 
                 Assert.False(del("123", default, out _));
             }
@@ -727,7 +733,10 @@ namespace Cesil.Tests
                 Assert.True(del("", default, out var v4));
                 Assert.Equal((_TestEnum?)null, v4);
 
-                Assert.False(del("foo", default, out _));
+                Assert.True(del("foo", default, out var v5));
+                Assert.Equal(_TestEnum.Foo, v5);
+
+                Assert.False(del("Fizz", default, out _));
 
                 Assert.False(del("123", default, out _));
             }
@@ -752,6 +761,9 @@ namespace Cesil.Tests
                 Assert.Equal((_TestFlagsEnum?)null, v4);
 
                 Assert.False(del("foo", default, out _));
+
+                Assert.True(del("first", default, out var v5));
+                Assert.Equal(_TestFlagsEnum.First, v5);
 
                 Assert.False(del("123", default, out _));
             }

--- a/Cesil/Cesil.xml
+++ b/Cesil/Cesil.xml
@@ -56,6 +56,12 @@
              * less than 0, the negated length of a value that didn't fit into copyInto
             </summary>
         </member>
+        <member name="M:Cesil.Utils.TryParseFlagsEnum``1(System.ReadOnlySpan{System.Char},System.String[],System.UInt64[],``0@)">
+            <summary>
+            This is _like_ calling TryParse(), but it doesn't allow values
+            that aren't actually declared on the enum.
+            </summary>
+        </member>
         <member name="M:Cesil.BoundConfigurationBase`1.#ctor(System.Buffers.MemoryPool{System.Char},System.Buffers.MemoryPool{Cesil.DynamicCellValue})">
             <summary>
             For some testing scenarios.

--- a/Cesil/TypeDescriber/Defaults/DefaultTypeParsers.cs
+++ b/Cesil/TypeDescriber/Defaults/DefaultTypeParsers.cs
@@ -16,6 +16,7 @@ namespace Cesil
             where T : struct, Enum
         {
             private static readonly T[] Values = CreateValues();
+            private static readonly ulong[] ULongValues = CreateULongValues();
             private static readonly string[] Names = CreateNames();
 
             internal static readonly Parser TryParseEnumParser = CreateTryParseEnumParser();
@@ -31,7 +32,31 @@ namespace Cesil
                     return Array.Empty<T>();
                 }
 
-                return Enum.GetValues(typeof(T).GetTypeInfo()).Cast<T>().ToArray();
+                return Enum.GetValues(enumType).Cast<T>().ToArray();
+            }
+
+            private static ulong[] CreateULongValues()
+            {
+                var enumType = typeof(T).GetTypeInfo();
+
+                // note that this is different from CreateValues()
+                //   which means these don't match like they do in formatting
+                if (!enumType.IsFlagsEnum())
+                {
+                    // only need ULongValues for [Flags] enums
+                    return Array.Empty<ulong>();
+                }
+
+                var values = Enum.GetValues(enumType);
+                var ret = new ulong[values.Length];
+                for(var i = 0; i < values.Length; i++)
+                {
+                    var obj = values.GetValue(i);
+                    obj = Utils.NonNull(obj);
+                    ret[i] = Utils.EnumToULong((T)obj);
+                }
+
+                return ret;
             }
 
             private static string[] CreateNames()
@@ -115,7 +140,8 @@ namespace Cesil
                 for (var i = 0; i < Names.Length; i++)
                 {
                     var name = Names[i];
-                    var cmp = span.CompareTo(name.AsSpan(), StringComparison.InvariantCulture);
+                    // use CompareTo because we need to allow different casings
+                    var cmp = span.CompareTo(name.AsSpan(), StringComparison.InvariantCultureIgnoreCase);
                     if (cmp == 0)
                     {
                         val = Values[i];
@@ -147,39 +173,12 @@ namespace Cesil
 
             private static bool TryParseFlagsEnum(ReadOnlySpan<char> data, in ReadContext _, out T val)
             {
-                // no real choice but to make a copy
-                // todo: get rid of this allocation once https://github.com/dotnet/corefx/issues/15453 (tracking issue: https://github.com/kevin-montrose/Cesil/issues/7)
-                //       is fixed, introducing a ReadOnlySpan<char> taking TryParse
-                var str = new string(data);
-
-                if (!Enum.TryParse(str, out val))
+                if(!Utils.TryParseFlagsEnum(data, Names, ULongValues, out val))
                 {
-                    return false;
-                }
-
-                // have to check to see if it's valid
-                var pieces = str.Split(DefaultTypeFormatters.COMMA_AND_SPACE, StringSplitOptions.RemoveEmptyEntries);
-                for (var i = 0; i < pieces.Length; i++)
-                {
-                    var piece = pieces[i];
-                    var found = false;
-                    for (var j = 0; j < Names.Length; j++)
-                    {
-                        var name = Names[j];
-                        if (piece.Equals(name, StringComparison.InvariantCulture))
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if (!found)
-                    {
 #pragma warning disable CES0005     // T is generic, so we can't annotate it, but it needs a default value
-                        val = default!;
-#pragma warning restore CES0005
-                        return false;
-                    }
+                    val = default!;
+#pragma warning restore CES0005     
+                    return false;
                 }
 
                 return true;


### PR DESCRIPTION
Closes #7.  This also fixes some bugs around allowing different casings to be parsed, which is the documented and intended behavior.

### Visible changes

 - Different case enums will now be successfully parsed, as intended.

### Internal changes (optional)

 - `Utils` grows two new methods, [`ULongToEnum<T>`](https://github.com/kevin-montrose/Cesil/compare/vNext...issue-7/remove-parse-enum-allocations?expand=1#diff-51c0b1a1fa14bd48d361f86332be01cfR1259) and [`TryParseFlagsEnum<T>`](https://github.com/kevin-montrose/Cesil/compare/vNext...issue-7/remove-parse-enum-allocations?expand=1#diff-51c0b1a1fa14bd48d361f86332be01cfR1320)
 - The default parsers for enums are now allocation free