### PR TITLE
Remove copying of data that happens when a range is taken of a DynamicRow

### DIFF
--- a/Cesil.Tests/AnalyzerTests.cs
+++ b/Cesil.Tests/AnalyzerTests.cs
@@ -772,6 +772,7 @@ namespace Cesil
     public class DynamicRow { }
     public class DynamicRowEnumerable<T> { }
     public class DynamicRowEnumerableNonGeneric { }
+    public class DynamicRowRange { }
     public class PassthroughRowEnumerable { }
     public class DefaultTypeDescriber { }
 

--- a/Cesil.Tests/DisposalTests.cs
+++ b/Cesil.Tests/DisposalTests.cs
@@ -18,6 +18,28 @@ namespace Cesil.Tests
 #pragma warning disable IDE1006
     public class DisposalTests
     {
+        private sealed class _IDisposable_DynamicRowOwner : IDynamicRowOwner
+        {
+            public Options Options => Options.Default;
+
+            public object Context => null;
+
+            public NameLookup AcquireNameLookup()
+            => default;
+
+            public void ReleaseNameLookup() { }
+
+            public void Remove(DynamicRow row) { }
+
+            void IDelegateCache.AddDelegate<T, V>(T key, V cached) { }
+
+            bool IDelegateCache.TryGetDelegate<T, V>(T key, out V del)
+            {
+                del = default;
+                return false;
+            }
+        }
+
         private static IEnumerable<TypeInfo> ShouldThrowOnUseAfterDispose<TDisposeInterface>()
         {
             var disposeI = typeof(TDisposeInterface).GetTypeInfo();
@@ -285,9 +307,53 @@ namespace Cesil.Tests
                 {
                     IDisposable_EncodedColumnTracker();
                 }
+                else if (t == typeof(DynamicRowRange))
+                {
+                    IDisposable_DynamicRowRange();
+                }
                 else
                 {
                     throw new XunitException($"No test configured for .Dispose() on {t.Name}");
+                }
+            }
+
+            void IDisposable_DynamicRowRange()
+            {
+                // double dispose does not error
+                {
+                    var r = MakeDynamicRowRange();
+                    Assert.False(r.IsDisposed);
+                    r.Dispose();
+                    r.Dispose();
+                }
+
+                // assert throws after dispose
+                {
+                    var r = MakeDynamicRowRange();
+                    r.Dispose();
+                    Assert.Throws<ObjectDisposedException>(() => ((ITestableDisposable)r).AssertNotDisposed());
+                }
+
+                var testCases = 0;
+
+                // figure out how many _public_ methods need testing
+                int expectedTestCases;
+                {
+                    using (var a = MakeDynamicRowRange())
+                    {
+                        expectedTestCases = GetNumberExpectedDisposableTestCases(a);
+                    }
+                }
+
+                Assert.Equal(expectedTestCases, testCases);
+
+                // make an adapter that's "good to go"
+                static DynamicRowRange MakeDynamicRowRange()
+                {
+                    var row = new DynamicRow();
+                    row.Init(new _IDisposable_DynamicRowOwner(), 0, null, TypeDescribers.Default, false, null, 0, MemoryPool<char>.Shared);
+
+                    return new DynamicRowRange(row, 0, 0);
                 }
             }
 
@@ -296,6 +362,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var e = MakeEncodedColumnTracker();
+                    Assert.False(e.IsDisposed);
                     e.Dispose();
                     e.Dispose();
                 }
@@ -335,6 +402,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var a = MakeOrdererNames();
+                    Assert.False(a.IsDisposed);
                     a.Dispose();
                     a.Dispose();
                 }
@@ -369,6 +437,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var a = MakeEnumerator();
+                    Assert.False(a.IsDisposed);
                     a.Dispose();
                     a.Dispose();
                 }
@@ -439,6 +508,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var a = MakeLookupAdapter();
+                    Assert.False(a.IsDisposed);
                     a.Dispose();
                     a.Dispose();
                 }
@@ -476,6 +546,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var a = MakeAdapter();
+                    Assert.False(a.IsDisposed);
                     a.Dispose();
                     a.Dispose();
                 }
@@ -529,6 +600,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var a = MakeAdapter();
+                    Assert.False(a.IsDisposed);
                     a.Dispose();
                     a.Dispose();
                 }
@@ -574,6 +646,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var e = MakeEnumerator();
+                    Assert.False(e.IsDisposed);
                     e.Dispose();
                     e.Dispose();
                 }
@@ -640,6 +713,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -685,6 +759,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False(w.IsDisposed);
                     w.Dispose();
                     w.Dispose();
                 }
@@ -738,6 +813,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -783,6 +859,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False(w.IsDisposed);
                     w.Dispose();
                     w.Dispose();
                 }
@@ -836,6 +913,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False((r as ITestableDisposable).IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -935,6 +1013,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -983,6 +1062,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False((w as ITestableDisposable).IsDisposed);
                     w.Dispose();
                     w.Dispose();
                 }
@@ -1057,6 +1137,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var b = MakeBuffer();
+                    Assert.False(b.IsDisposed);
                     b.Dispose();
                     b.Dispose();
                 }
@@ -1098,6 +1179,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var b = MakeBuffer();
+                    Assert.False(b.IsDisposed);
                     b.Dispose();
                     b.Dispose();
                 }
@@ -1135,6 +1217,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var p = MakePartial();
+                    Assert.False(p.IsDisposed);
                     p.Dispose();
                     p.Dispose();
                 }
@@ -1172,6 +1255,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var d = MakeDetector();
+                    Assert.False(d.IsDisposed);
                     d.Dispose();
                     d.Dispose();
                 }
@@ -1216,6 +1300,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -1266,6 +1351,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var e = MakeEnumerator();
+                    Assert.False(e.IsDisposed);
                     e.Dispose();
                     e.Dispose();
                 }
@@ -1327,6 +1413,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var l = MakeLookup();
+                    Assert.False(l.IsDisposed);
                     l.Dispose();
                     l.Dispose();
                 }
@@ -1364,6 +1451,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False(w.IsDisposed);
                     w.Dispose();
                     w.Dispose();
                 }
@@ -1425,6 +1513,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False((r as ITestableDisposable).IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -1522,6 +1611,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeRow();
+                    Assert.False(r.IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -1549,7 +1639,10 @@ namespace Cesil.Tests
                 // make a reader that's "good to go"
                 static DynamicRow MakeRow()
                 {
-                    return new DynamicRow();
+                    var row = new DynamicRow();
+                    row.Init(new _IDisposable_DynamicRowOwner(), 0, null, TypeDescribers.Default, false, null, 0, MemoryPool<char>.Shared);
+
+                    return row;
                 }
             }
 
@@ -1559,6 +1652,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeDynamicRowEnumerator();
+                    Assert.False((r as ITestableDisposable).IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -1630,6 +1724,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeEnumerable();
+                    Assert.False((r as ITestableDisposable).IsDisposed);
                     r.Dispose();
                     r.Dispose();
                 }
@@ -1688,6 +1783,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False((w as ITestableDisposable).IsDisposed);
                     w.Dispose();
                     w.Dispose();
                 }
@@ -1889,6 +1985,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeAsyncEnumerableAdapter();
+                    Assert.False((w as ITestableAsyncDisposable).IsDisposed);
                     await w.DisposeAsync();
                     await w.DisposeAsync();
                 }
@@ -1950,6 +2047,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeAsyncEnumerable();
+                    Assert.False((w as ITestableAsyncDisposable).IsDisposed);
                     await w.DisposeAsync();
                     await w.DisposeAsync();
                 }
@@ -2002,6 +2100,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False(w.IsDisposed);
                     await w.DisposeAsync();
                     await w.DisposeAsync();
                 }
@@ -2040,6 +2139,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     await r.DisposeAsync();
                     await r.DisposeAsync();
                 }
@@ -2078,6 +2178,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False(r.IsDisposed);
                     await r.DisposeAsync();
                     await r.DisposeAsync();
                 }
@@ -2116,6 +2217,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeWriter();
+                    Assert.False(r.IsDisposed);
                     await r.DisposeAsync();
                     await r.DisposeAsync();
                 }
@@ -2154,6 +2256,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False((r as ITestableAsyncDisposable).IsDisposed);
                     await r.DisposeAsync();
                     await r.DisposeAsync();
                 }
@@ -2242,6 +2345,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False((w as ITestableAsyncDisposable).IsDisposed);
                     await w.DisposeAsync();
                     await w.DisposeAsync();
                 }
@@ -2314,6 +2418,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var r = MakeReader();
+                    Assert.False((r as ITestableAsyncDisposable).IsDisposed);
                     await r.DisposeAsync();
                     await r.DisposeAsync();
                 }
@@ -2402,6 +2507,7 @@ namespace Cesil.Tests
                 // double dispose does not error
                 {
                     var w = MakeWriter();
+                    Assert.False((w as ITestableAsyncDisposable).IsDisposed);
                     await w.DisposeAsync();
                     await w.DisposeAsync();
                 }

--- a/Cesil.Tests/DynamicReaderTests.cs
+++ b/Cesil.Tests/DynamicReaderTests.cs
@@ -320,6 +320,12 @@ namespace Cesil.Tests
                     IEnumerable<string> enumerable = dyn;
                     Assert.Equal(new[] { "1", "2", "3" }, enumerable);
 
+                    IEnumerable<dynamic> enumerableDyn = dyn;
+                    {
+                        var asInt = enumerableDyn.Select(i => (int)i).ToList();
+                        Assert.Equal(new[] { 1, 2, 3 }, asInt);
+                    }
+
                     _DynamicRowRange_Cons1 c1 = dyn;
                     Assert.Equal(1, c1.One);
                     Assert.Equal(2, c1.Two);
@@ -338,19 +344,19 @@ namespace Cesil.Tests
                         a =>
                         {
                             Assert.Equal(0, a.Id.Index);
-                            Assert.Equal("A", a.Id.Name);
+                            AssertEqual("A", a.Id);
                             Assert.Equal("1", a.Value);
                         },
                         b =>
                         {
                             Assert.Equal(1, b.Id.Index);
-                            Assert.Equal("B", b.Id.Name);
+                            AssertEqual("B", b.Id);
                             Assert.Equal("2", b.Value);
                         },
                         c =>
                         {
                             Assert.Equal(2, c.Id.Index);
-                            Assert.Equal("C", c.Id.Name);
+                            AssertEqual("C", c.Id);
                             Assert.Equal("3", c.Value);
                         }
                     );
@@ -372,6 +378,12 @@ namespace Cesil.Tests
                     IEnumerable<string> enumerable = dyn;
                     Assert.Equal(new[] { "2", "3" }, enumerable);
 
+                    IEnumerable<dynamic> enumerableDyn = dyn;
+                    {
+                        var asInt = enumerableDyn.Select(i => (int)i).ToList();
+                        Assert.Equal(new[] { 2, 3 }, asInt);
+                    }
+
                     _DynamicRowRange_Cons1 c1 = dyn;
                     Assert.Equal(2, c1.One);
                     Assert.Equal(3, c1.Two);
@@ -390,13 +402,13 @@ namespace Cesil.Tests
                         b =>
                         {
                             Assert.Equal(0, b.Id.Index);
-                            Assert.Equal("B", b.Id.Name);
+                            AssertEqual("B", b.Id);
                             Assert.Equal("2", b.Value);
                         },
                         c =>
                         {
                             Assert.Equal(1, c.Id.Index);
-                            Assert.Equal("C", c.Id.Name);
+                            AssertEqual("C", c.Id);
                             Assert.Equal("3", c.Value);
                         }
                     );
@@ -418,6 +430,12 @@ namespace Cesil.Tests
                     IEnumerable<string> enumerable = dyn;
                     Assert.Equal(new[] { "1", "2" }, enumerable);
 
+                    IEnumerable<dynamic> enumerableDyn = dyn;
+                    {
+                        var asInt = enumerableDyn.Select(i => (int)i).ToList();
+                        Assert.Equal(new[] { 1, 2 }, asInt);
+                    }
+
                     _DynamicRowRange_Cons1 c1 = dyn;
                     Assert.Equal(1, c1.One);
                     Assert.Equal(2, c1.Two);
@@ -436,13 +454,13 @@ namespace Cesil.Tests
                         b =>
                         {
                             Assert.Equal(0, b.Id.Index);
-                            Assert.Equal("A", b.Id.Name);
+                            AssertEqual("A", b.Id);
                             Assert.Equal("1", b.Value);
                         },
                         c =>
                         {
                             Assert.Equal(1, c.Id.Index);
-                            Assert.Equal("B", c.Id.Name);
+                            AssertEqual("B", c.Id);
                             Assert.Equal("2", c.Value);
                         }
                     );
@@ -467,6 +485,12 @@ namespace Cesil.Tests
                         IEnumerable<string> enumerable = r;
                         Assert.Equal(new[] { "1", "2", "3" }, enumerable);
 
+                        IEnumerable<dynamic> enumerableDyn = r;
+                        {
+                            var asInt = enumerableDyn.Select(i => (int)i).ToList();
+                            Assert.Equal(new[] { 1, 2, 3 }, asInt);
+                        }
+
                         _DynamicRowRange_Cons1 c1 = r;
                         Assert.Equal(1, c1.One);
                         Assert.Equal(2, c1.Two);
@@ -485,19 +509,19 @@ namespace Cesil.Tests
                             a =>
                             {
                                 Assert.Equal(0, a.Id.Index);
-                                Assert.Equal("A", a.Id.Name);
+                                AssertEqual("A", a.Id);
                                 Assert.Equal("1", a.Value);
                             },
                             b =>
                             {
                                 Assert.Equal(1, b.Id.Index);
-                                Assert.Equal("B", b.Id.Name);
+                                AssertEqual("B", b.Id);
                                 Assert.Equal("2", b.Value);
                             },
                             c =>
                             {
                                 Assert.Equal(2, c.Id.Index);
-                                Assert.Equal("C", c.Id.Name);
+                                AssertEqual("C", c.Id);
                                 Assert.Equal("3", c.Value);
                             }
                         );
@@ -683,6 +707,20 @@ namespace Cesil.Tests
                     IEnumerable<string> e12 = subDyn12;
                     Assert.Equal(new[] { "1" }, e12);
                 }
+            }
+
+            // check both
+            static void AssertEqual(string expectedName, ColumnIdentifier ci)
+            {
+                Assert.Equal(expectedName, ci.Name);
+
+                var memName = ci.NameMemory;
+
+                Assert.True(Utils.AreEqual(expectedName.AsMemory(), memName));
+
+                var nameAgain = ci.NameMemory;
+
+                Assert.Equal(nameAgain, memName);
             }
         }
 

--- a/Cesil.Tests/DynamicReaderTests.cs
+++ b/Cesil.Tests/DynamicReaderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Globalization;
@@ -15,6 +16,676 @@ namespace Cesil.Tests
 {
     public class DynamicReaderTests
     {
+        private sealed class _DynamicRowRange : DefaultTypeDescriber
+        {
+            private static readonly ConcurrentDictionary<string, DynamicRowConverter> Cache = new ConcurrentDictionary<string, DynamicRowConverter>();
+
+            private static readonly DynamicRowConverter TwoParamCons =
+                DynamicRowConverter.ForConstructorTakingTypedParameters(
+                    typeof(_DynamicRowRange_Cons1).GetConstructor(new[] { typeof(int), typeof(int) }),
+                    new[] { ColumnIdentifier.Create(0), ColumnIdentifier.Create(1) }
+                );
+
+            private static readonly DynamicRowConverter OneParamCons =
+                DynamicRowConverter.ForConstructorTakingDynamic(
+                    typeof(_DynamicRowRange_Cons2).GetConstructor(new[] { typeof(object) })
+                );
+
+            private static readonly DynamicRowConverter ZeroParamCons_ABC =
+                DynamicRowConverter.ForEmptyConstructorAndSetters(
+                    typeof(_DynamicRowRange_Cons3).GetConstructor(Array.Empty<Type>()),
+                    new[]
+                    {
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int a, in ReadContext _) => {row.A = a; }),
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int b, in ReadContext _) => {row.B = b; }),
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int c, in ReadContext _) => {row.C = c; }),
+                    },
+                    new[]
+                    {
+                        ColumnIdentifier.Create(0),
+                        ColumnIdentifier.Create(1),
+                        ColumnIdentifier.Create(2)
+                    }
+                );
+
+            private static readonly DynamicRowConverter ZeroParamCons_AB =
+                DynamicRowConverter.ForEmptyConstructorAndSetters(
+                    typeof(_DynamicRowRange_Cons3).GetConstructor(Array.Empty<Type>()),
+                    new[]
+                    {
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int a, in ReadContext _) => {row.A = a; }),
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int b, in ReadContext _) => {row.B = b; }),
+                    },
+                    new[]
+                    {
+                        ColumnIdentifier.Create(0),
+                        ColumnIdentifier.Create(1)
+                    }
+                );
+
+            private static readonly DynamicRowConverter ZeroParamCons_BC =
+               DynamicRowConverter.ForEmptyConstructorAndSetters(
+                   typeof(_DynamicRowRange_Cons3).GetConstructor(Array.Empty<Type>()),
+                   new[]
+                   {
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int b, in ReadContext _) => {row.B = b; }),
+                        Setter.ForDelegate((_DynamicRowRange_Cons3 row, int c, in ReadContext _) => {row.C = c; }),
+                   },
+                   new[]
+                   {
+                        ColumnIdentifier.Create(0),
+                        ColumnIdentifier.Create(1)
+                   }
+               );
+
+            public override DynamicRowConverter GetDynamicRowConverter(in ReadContext context, IEnumerable<ColumnIdentifier> columns, TypeInfo targetType)
+            {
+                if (targetType == typeof(List<(ColumnIdentifier Id, string Value)>).GetTypeInfo())
+                {
+                    var key = string.Join(", ", columns.Select(c => $"{c.Index},{c.Name}"));
+
+                    if (Cache.TryGetValue(key, out var ret))
+                    {
+                        return ret;
+                    }
+
+                    ret =
+                        DynamicRowConverter.ForDelegate(
+                            (dynamic row, in ReadContext context, out List<(ColumnIdentifier Id, string Value)> result) =>
+                            {
+                                result = new List<(ColumnIdentifier Id, string Value)>();
+
+                                foreach (var col in columns)
+                                {
+                                    string val = row[col.Index];
+                                    result.Add((col, val));
+                                }
+
+                                return true;
+                            }
+                        );
+
+                    Cache.TryAdd(key, ret);
+
+                    return ret;
+                }
+
+                if (targetType == typeof(_DynamicRowRange_Cons1).GetTypeInfo())
+                {
+                    return TwoParamCons;
+                }
+
+                if (targetType == typeof(_DynamicRowRange_Cons2).GetTypeInfo())
+                {
+                    return OneParamCons;
+                }
+
+                if (targetType == typeof(_DynamicRowRange_Cons3).GetTypeInfo())
+                {
+                    switch (columns.Count())
+                    {
+                        case 3: return ZeroParamCons_ABC;
+                        case 2:
+                            if (columns.Any(c => c.Name == "A"))
+                            {
+                                return ZeroParamCons_AB;
+                            }
+
+                            return ZeroParamCons_BC;
+                        default: throw new Exception("Wat");
+                    }
+                }
+
+                return base.GetDynamicRowConverter(in context, columns, targetType);
+            }
+        }
+
+        private sealed class _DynamicRowRange_Cons1
+        {
+            public int One { get; set; }
+            public int Two { get; set; }
+
+            public _DynamicRowRange_Cons1(int one, int two)
+            {
+                One = one;
+                Two = two;
+            }
+        }
+
+        private sealed class _DynamicRowRange_Cons2
+        {
+            public IEnumerable<string> Values { get; set; }
+
+            public _DynamicRowRange_Cons2(dynamic val)
+            {
+                IEnumerable<string> e = val;
+
+                Values = e.ToList();
+            }
+        }
+
+        private sealed class _DynamicRowRange_Cons3
+        {
+            public int A { get; set; }
+            public int B { get; set; }
+            public int C { get; set; }
+
+            public _DynamicRowRange_Cons3() { }
+        }
+
+        [Fact]
+        public void DynamicRowRange()
+        {
+            var opts = Options.CreateBuilder(Options.DynamicDefault).WithTypeDescriber(new _DynamicRowRange()).ToOptions();
+            var config = Configuration.ForDynamic(opts);
+
+            using var reader = new StringReader("A,B,C\r\n1,2,3");
+            using var csv = config.CreateReader(reader);
+
+            var row = csv.ReadAll().Single() as DynamicRow;
+            Assert.NotNull(row);
+
+            // BindGetMember & BindGetIndex
+            {
+                // no change
+                {
+                    var range = new DynamicRowRange(row, 0, 3);
+                    dynamic dyn = range;
+
+                    Assert.Equal(1, (int)dyn[0]);
+                    Assert.Equal(1, (int)dyn[(Index)0]);
+                    Assert.Equal(1, (int)dyn[^3]);
+                    Assert.Equal(1, (int)dyn.A);
+                    Assert.Equal(1, (int)dyn["A"]);
+                    Assert.Equal(1, (int)dyn[ColumnIdentifier.Create(0)]);
+                    Assert.Equal(1, (int)dyn[ColumnIdentifier.Create(0, "A")]);
+
+                    Assert.Equal(2, (int)dyn[1]);
+                    Assert.Equal(2, (int)dyn[(Index)1]);
+                    Assert.Equal(2, (int)dyn[^2]);
+                    Assert.Equal(2, (int)dyn.B);
+                    Assert.Equal(2, (int)dyn["B"]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(1)]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(1, "B")]);
+
+                    Assert.Equal(3, (int)dyn[2]);
+                    Assert.Equal(3, (int)dyn[(Index)2]);
+                    Assert.Equal(3, (int)dyn[^1]);
+                    Assert.Equal(3, (int)dyn.C);
+                    Assert.Equal(3, (int)dyn["C"]);
+                    Assert.Equal(3, (int)dyn[ColumnIdentifier.Create(2)]);
+                    Assert.Equal(3, (int)dyn[ColumnIdentifier.Create(2, "C")]);
+                }
+
+                // shift right
+                {
+                    var range = new DynamicRowRange(row, 1, 2);
+                    dynamic dyn = range;
+
+                    Assert.Throws<ArgumentOutOfRangeException>(() => dyn[2]);
+                    Assert.Throws<KeyNotFoundException>(() => dyn.A);
+
+                    Assert.Equal(2, (int)dyn[0]);
+                    Assert.Equal(2, (int)dyn[(Index)0]);
+                    Assert.Equal(2, (int)dyn[^2]);
+                    Assert.Equal(2, (int)dyn.B);
+                    Assert.Equal(2, (int)dyn["B"]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(0)]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(0, "B")]);
+
+                    Assert.Equal(3, (int)dyn[1]);
+                    Assert.Equal(3, (int)dyn[(Index)1]);
+                    Assert.Equal(3, (int)dyn[^1]);
+                    Assert.Equal(3, (int)dyn.C);
+                    Assert.Equal(3, (int)dyn["C"]);
+                    Assert.Equal(3, (int)dyn[ColumnIdentifier.Create(1)]);
+                    Assert.Equal(3, (int)dyn[ColumnIdentifier.Create(1, "C")]);
+                }
+
+                // shift left
+                {
+                    var range = new DynamicRowRange(row, 0, 2);
+                    dynamic dyn = range;
+
+                    Assert.Throws<ArgumentOutOfRangeException>(() => dyn[2]);
+                    Assert.Throws<KeyNotFoundException>(() => dyn.C);
+
+                    Assert.Equal(1, (int)dyn[0]);
+                    Assert.Equal(1, (int)dyn[(Index)0]);
+                    Assert.Equal(1, (int)dyn[^2]);
+                    Assert.Equal(1, (int)dyn.A);
+                    Assert.Equal(1, (int)dyn["A"]);
+                    Assert.Equal(1, (int)dyn[ColumnIdentifier.Create(0)]);
+                    Assert.Equal(1, (int)dyn[ColumnIdentifier.Create(0, "A")]);
+
+                    Assert.Equal(2, (int)dyn[1]);
+                    Assert.Equal(2, (int)dyn[(Index)1]);
+                    Assert.Equal(2, (int)dyn[^1]);
+                    Assert.Equal(2, (int)dyn.B);
+                    Assert.Equal(2, (int)dyn["B"]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(1)]);
+                    Assert.Equal(2, (int)dyn[ColumnIdentifier.Create(1, "B")]);
+                }
+
+                // swap dynamic types
+                {
+                    var rows = new[] { (dynamic)row, (dynamic)new DynamicRowRange(row, 0, 3) };
+
+                    foreach (var r in rows)
+                    {
+                        Assert.Equal(1, (int)r[0]);
+                        Assert.Equal(1, (int)r[(Index)0]);
+                        Assert.Equal(1, (int)r[^3]);
+                        Assert.Equal(1, (int)r.A);
+                        Assert.Equal(1, (int)r["A"]);
+                        Assert.Equal(1, (int)r[ColumnIdentifier.Create(0)]);
+                        Assert.Equal(1, (int)r[ColumnIdentifier.Create(0, "A")]);
+
+                        Assert.Equal(2, (int)r[1]);
+                        Assert.Equal(2, (int)r[(Index)1]);
+                        Assert.Equal(2, (int)r[^2]);
+                        Assert.Equal(2, (int)r.B);
+                        Assert.Equal(2, (int)r["B"]);
+                        Assert.Equal(2, (int)r[ColumnIdentifier.Create(1)]);
+                        Assert.Equal(2, (int)r[ColumnIdentifier.Create(1, "B")]);
+
+                        Assert.Equal(3, (int)r[2]);
+                        Assert.Equal(3, (int)r[(Index)2]);
+                        Assert.Equal(3, (int)r[^1]);
+                        Assert.Equal(3, (int)r.C);
+                        Assert.Equal(3, (int)r["C"]);
+                        Assert.Equal(3, (int)r[ColumnIdentifier.Create(2)]);
+                        Assert.Equal(3, (int)r[ColumnIdentifier.Create(2, "C")]);
+                    }
+                }
+            }
+
+            // conversions
+            {
+                // no change
+                {
+                    var range = new DynamicRowRange(row, 0, 3);
+                    dynamic dyn = range;
+
+                    (int First, int Second, int Third) tuple = dyn;
+                    Assert.Equal(1, tuple.First);
+                    Assert.Equal(2, tuple.Second);
+                    Assert.Equal(3, tuple.Third);
+
+                    Tuple<int, int, int> refTuple = dyn;
+                    Assert.Equal(1, refTuple.Item1);
+                    Assert.Equal(2, refTuple.Item2);
+                    Assert.Equal(3, refTuple.Item3);
+
+                    IEnumerable<string> enumerable = dyn;
+                    Assert.Equal(new[] { "1", "2", "3" }, enumerable);
+
+                    _DynamicRowRange_Cons1 c1 = dyn;
+                    Assert.Equal(1, c1.One);
+                    Assert.Equal(2, c1.Two);
+
+                    _DynamicRowRange_Cons2 c2 = dyn;
+                    Assert.Equal(new[] { "1", "2", "3" }, c2.Values);
+
+                    _DynamicRowRange_Cons3 c3 = dyn;
+                    Assert.Equal(1, c3.A);
+                    Assert.Equal(2, c3.B);
+                    Assert.Equal(3, c3.C);
+
+                    List<(ColumnIdentifier Id, string Value)> extracted = dyn;
+                    Assert.Collection(
+                        extracted,
+                        a =>
+                        {
+                            Assert.Equal(0, a.Id.Index);
+                            Assert.Equal("A", a.Id.Name);
+                            Assert.Equal("1", a.Value);
+                        },
+                        b =>
+                        {
+                            Assert.Equal(1, b.Id.Index);
+                            Assert.Equal("B", b.Id.Name);
+                            Assert.Equal("2", b.Value);
+                        },
+                        c =>
+                        {
+                            Assert.Equal(2, c.Id.Index);
+                            Assert.Equal("C", c.Id.Name);
+                            Assert.Equal("3", c.Value);
+                        }
+                    );
+                }
+
+                // shift left
+                {
+                    var range = new DynamicRowRange(row, 1, 2);
+                    dynamic dyn = range;
+
+                    (int First, int Second) tuple = dyn;
+                    Assert.Equal(2, tuple.First);
+                    Assert.Equal(3, tuple.Second);
+
+                    Tuple<int, int> refTuple = dyn;
+                    Assert.Equal(2, refTuple.Item1);
+                    Assert.Equal(3, refTuple.Item2);
+
+                    IEnumerable<string> enumerable = dyn;
+                    Assert.Equal(new[] { "2", "3" }, enumerable);
+
+                    _DynamicRowRange_Cons1 c1 = dyn;
+                    Assert.Equal(2, c1.One);
+                    Assert.Equal(3, c1.Two);
+
+                    _DynamicRowRange_Cons2 c2 = dyn;
+                    Assert.Equal(new[] { "2", "3" }, c2.Values);
+
+                    _DynamicRowRange_Cons3 c3 = dyn;
+                    Assert.Equal(0, c3.A);
+                    Assert.Equal(2, c3.B);
+                    Assert.Equal(3, c3.C);
+
+                    List<(ColumnIdentifier Id, string Value)> extracted = dyn;
+                    Assert.Collection(
+                        extracted,
+                        b =>
+                        {
+                            Assert.Equal(0, b.Id.Index);
+                            Assert.Equal("B", b.Id.Name);
+                            Assert.Equal("2", b.Value);
+                        },
+                        c =>
+                        {
+                            Assert.Equal(1, c.Id.Index);
+                            Assert.Equal("C", c.Id.Name);
+                            Assert.Equal("3", c.Value);
+                        }
+                    );
+                }
+
+                // shift right
+                {
+                    var range = new DynamicRowRange(row, 0, 2);
+                    dynamic dyn = range;
+
+                    (int First, int Second) tuple = dyn;
+                    Assert.Equal(1, tuple.First);
+                    Assert.Equal(2, tuple.Second);
+
+                    Tuple<int, int> refTuple = dyn;
+                    Assert.Equal(1, refTuple.Item1);
+                    Assert.Equal(2, refTuple.Item2);
+
+                    IEnumerable<string> enumerable = dyn;
+                    Assert.Equal(new[] { "1", "2" }, enumerable);
+
+                    _DynamicRowRange_Cons1 c1 = dyn;
+                    Assert.Equal(1, c1.One);
+                    Assert.Equal(2, c1.Two);
+
+                    _DynamicRowRange_Cons2 c2 = dyn;
+                    Assert.Equal(new[] { "1", "2" }, c2.Values);
+
+                    _DynamicRowRange_Cons3 c3 = dyn;
+                    Assert.Equal(1, c3.A);
+                    Assert.Equal(2, c3.B);
+                    Assert.Equal(0, c3.C);
+
+                    List<(ColumnIdentifier Id, string Value)> extracted = dyn;
+                    Assert.Collection(
+                        extracted,
+                        b =>
+                        {
+                            Assert.Equal(0, b.Id.Index);
+                            Assert.Equal("A", b.Id.Name);
+                            Assert.Equal("1", b.Value);
+                        },
+                        c =>
+                        {
+                            Assert.Equal(1, c.Id.Index);
+                            Assert.Equal("B", c.Id.Name);
+                            Assert.Equal("2", c.Value);
+                        }
+                    );
+                }
+
+                // swap dynamic types
+                {
+                    var rows = new[] { (dynamic)row, (dynamic)new DynamicRowRange(row, 0, 3) };
+
+                    foreach (var r in rows)
+                    {
+                        (int First, int Second, int Third) tuple = r;
+                        Assert.Equal(1, tuple.First);
+                        Assert.Equal(2, tuple.Second);
+                        Assert.Equal(3, tuple.Third);
+
+                        Tuple<int, int, int> refTuple = r;
+                        Assert.Equal(1, refTuple.Item1);
+                        Assert.Equal(2, refTuple.Item2);
+                        Assert.Equal(3, refTuple.Item3);
+
+                        IEnumerable<string> enumerable = r;
+                        Assert.Equal(new[] { "1", "2", "3" }, enumerable);
+
+                        _DynamicRowRange_Cons1 c1 = r;
+                        Assert.Equal(1, c1.One);
+                        Assert.Equal(2, c1.Two);
+
+                        _DynamicRowRange_Cons2 c2 = r;
+                        Assert.Equal(new[] { "1", "2", "3" }, c2.Values);
+
+                        _DynamicRowRange_Cons3 c3 = r;
+                        Assert.Equal(1, c3.A);
+                        Assert.Equal(2, c3.B);
+                        Assert.Equal(3, c3.C);
+
+                        List<(ColumnIdentifier Id, string Value)> extracted = r;
+                        Assert.Collection(
+                            extracted,
+                            a =>
+                            {
+                                Assert.Equal(0, a.Id.Index);
+                                Assert.Equal("A", a.Id.Name);
+                                Assert.Equal("1", a.Value);
+                            },
+                            b =>
+                            {
+                                Assert.Equal(1, b.Id.Index);
+                                Assert.Equal("B", b.Id.Name);
+                                Assert.Equal("2", b.Value);
+                            },
+                            c =>
+                            {
+                                Assert.Equal(2, c.Id.Index);
+                                Assert.Equal("C", c.Id.Name);
+                                Assert.Equal("3", c.Value);
+                            }
+                        );
+                    }
+                }
+            }
+
+            // (sub)ranges
+            {
+                // no change
+                {
+                    var range = new DynamicRowRange(row, 0, 3);
+                    dynamic dyn = range;
+
+                    var subDyn1 = dyn[..];
+                    var subDyn2 = dyn[0..];
+                    var subDyn3 = dyn[0..3];
+                    var subDyn4 = dyn[^3..^0];
+
+                    IEnumerable<string> e1 = subDyn1;
+                    Assert.Equal(new[] { "1", "2", "3" }, e1);
+
+                    IEnumerable<string> e2 = subDyn2;
+                    Assert.Equal(new[] { "1", "2", "3" }, e2);
+
+                    IEnumerable<string> e3 = subDyn3;
+                    Assert.Equal(new[] { "1", "2", "3" }, e3);
+
+                    IEnumerable<string> e4 = subDyn4;
+                    Assert.Equal(new[] { "1", "2", "3" }, e4);
+
+                    // trim left
+                    var subDyn5 = dyn[1..];
+                    var subDyn6 = dyn[1..3];
+                    var subDyn7 = dyn[^2..3];
+                    var subDyn8 = dyn[^2..^0];
+
+                    IEnumerable<string> e5 = subDyn5;
+                    Assert.Equal(new[] { "2", "3" }, e5);
+
+                    IEnumerable<string> e6 = subDyn6;
+                    Assert.Equal(new[] { "2", "3" }, e6);
+
+                    IEnumerable<string> e7 = subDyn7;
+                    Assert.Equal(new[] { "2", "3" }, e7);
+
+                    IEnumerable<string> e8 = subDyn8;
+                    Assert.Equal(new[] { "2", "3" }, e8);
+
+                    // trim right
+                    var subDyn9 = dyn[..2];
+                    var subDyn10 = dyn[0..2];
+                    var subDyn11 = dyn[^3..2];
+                    var subDyn12 = dyn[^3..^1];
+
+                    IEnumerable<string> e9 = subDyn9;
+                    Assert.Equal(new[] { "1", "2" }, e9);
+
+                    IEnumerable<string> e10 = subDyn10;
+                    Assert.Equal(new[] { "1", "2" }, e10);
+
+                    IEnumerable<string> e11 = subDyn11;
+                    Assert.Equal(new[] { "1", "2" }, e11);
+
+                    IEnumerable<string> e12 = subDyn12;
+                    Assert.Equal(new[] { "1", "2" }, e12);
+                }
+
+                // trim left
+                {
+                    var range = new DynamicRowRange(row, 1, 2);
+                    dynamic dyn = range;
+
+                    var subDyn1 = dyn[..];
+                    var subDyn2 = dyn[0..];
+                    var subDyn3 = dyn[0..2];
+                    var subDyn4 = dyn[^2..^0];
+
+                    IEnumerable<string> e1 = subDyn1;
+                    Assert.Equal(new[] { "2", "3" }, e1);
+
+                    IEnumerable<string> e2 = subDyn2;
+                    Assert.Equal(new[] { "2", "3" }, e2);
+
+                    IEnumerable<string> e3 = subDyn3;
+                    Assert.Equal(new[] { "2", "3" }, e3);
+
+                    IEnumerable<string> e4 = subDyn4;
+                    Assert.Equal(new[] { "2", "3" }, e4);
+
+                    // trim left
+                    var subDyn5 = dyn[1..];
+                    var subDyn6 = dyn[1..2];
+                    var subDyn7 = dyn[^1..2];
+                    var subDyn8 = dyn[^1..^0];
+
+                    IEnumerable<string> e5 = subDyn5;
+                    Assert.Equal(new[] { "3" }, e5);
+
+                    IEnumerable<string> e6 = subDyn6;
+                    Assert.Equal(new[] { "3" }, e6);
+
+                    IEnumerable<string> e7 = subDyn7;
+                    Assert.Equal(new[] { "3" }, e7);
+
+                    IEnumerable<string> e8 = subDyn8;
+                    Assert.Equal(new[] { "3" }, e8);
+
+                    // trim right
+                    var subDyn9 = dyn[..1];
+                    var subDyn10 = dyn[0..1];
+                    var subDyn11 = dyn[^2..1];
+                    var subDyn12 = dyn[^2..^1];
+
+                    IEnumerable<string> e9 = subDyn9;
+                    Assert.Equal(new[] { "2" }, e9);
+
+                    IEnumerable<string> e10 = subDyn10;
+                    Assert.Equal(new[] { "2" }, e10);
+
+                    IEnumerable<string> e11 = subDyn11;
+                    Assert.Equal(new[] { "2" }, e11);
+
+                    IEnumerable<string> e12 = subDyn12;
+                    Assert.Equal(new[] { "2" }, e12);
+                }
+
+                // trim right
+                {
+                    var range = new DynamicRowRange(row, 0, 2);
+                    dynamic dyn = range;
+
+                    var subDyn1 = dyn[..];
+                    var subDyn2 = dyn[0..];
+                    var subDyn3 = dyn[0..2];
+                    var subDyn4 = dyn[^2..^0];
+
+                    IEnumerable<string> e1 = subDyn1;
+                    Assert.Equal(new[] { "1", "2" }, e1);
+
+                    IEnumerable<string> e2 = subDyn2;
+                    Assert.Equal(new[] { "1", "2" }, e2);
+
+                    IEnumerable<string> e3 = subDyn3;
+                    Assert.Equal(new[] { "1", "2" }, e3);
+
+                    IEnumerable<string> e4 = subDyn4;
+                    Assert.Equal(new[] { "1", "2" }, e4);
+
+                    // trim left
+                    var subDyn5 = dyn[1..];
+                    var subDyn6 = dyn[1..2];
+                    var subDyn7 = dyn[^1..2];
+                    var subDyn8 = dyn[^1..^0];
+
+                    IEnumerable<string> e5 = subDyn5;
+                    Assert.Equal(new[] { "2" }, e5);
+
+                    IEnumerable<string> e6 = subDyn6;
+                    Assert.Equal(new[] { "2" }, e6);
+
+                    IEnumerable<string> e7 = subDyn7;
+                    Assert.Equal(new[] { "2" }, e7);
+
+                    IEnumerable<string> e8 = subDyn8;
+                    Assert.Equal(new[] { "2" }, e8);
+
+                    // trim right
+                    var subDyn9 = dyn[..1];
+                    var subDyn10 = dyn[0..1];
+                    var subDyn11 = dyn[^2..1];
+                    var subDyn12 = dyn[^2..^1];
+
+                    IEnumerable<string> e9 = subDyn9;
+                    Assert.Equal(new[] { "1" }, e9);
+
+                    IEnumerable<string> e10 = subDyn10;
+                    Assert.Equal(new[] { "1" }, e10);
+
+                    IEnumerable<string> e11 = subDyn11;
+                    Assert.Equal(new[] { "1" }, e11);
+
+                    IEnumerable<string> e12 = subDyn12;
+                    Assert.Equal(new[] { "1" }, e12);
+                }
+            }
+        }
+
         private sealed class _DynamicRowGetDataIndex : IDynamicRowOwner
         {
             public Options Options => Options.Default;

--- a/Cesil.Tests/DynamicWriterTests.cs
+++ b/Cesil.Tests/DynamicWriterTests.cs
@@ -35,6 +35,36 @@ namespace Cesil.Tests
         }
 
         [Fact]
+        public void WriteRange()
+        {
+            var opts = Options.CreateBuilder(Options.DynamicDefault).WithWriteHeader(WriteHeader.Never).ToOptions();
+
+            RunSyncDynamicWriterVariants(
+                opts,
+                (config, getWriter, getStr) =>
+                {
+                    var row = MakeDynamicRow($"A,B,C,D\r\n1,2,3,4");
+                    var range1 = row[1..^1];
+                    var range2 = row[1..];
+
+                    using (var writer = getWriter())
+                    using(var csv = config.CreateWriter(writer))
+                    {
+                        csv.Write(range1);
+                        csv.Write(range2);
+                    }
+
+                    var res = getStr();
+                    Assert.Equal("2,3\r\n2,3,4", res);
+
+                    row.Dispose();
+                    range1.Dispose();
+                    range2.Dispose();
+                }
+            );
+        }
+
+        [Fact]
         public void WriteCommentErrors()
         {
             RunSyncDynamicWriterVariants(
@@ -2083,6 +2113,36 @@ namespace Cesil.Tests
         }
 
         // async tests
+
+        [Fact]
+        public async Task WriteRangeAsync()
+        {
+            var opts = Options.CreateBuilder(Options.DynamicDefault).WithWriteHeader(WriteHeader.Never).ToOptions();
+
+            await RunAsyncDynamicWriterVariants(
+                opts,
+                async (config, getWriter, getStr) =>
+                {
+                    var row = MakeDynamicRow($"A,B,C,D\r\n1,2,3,4");
+                    var range1 = row[1..^1];
+                    var range2 = row[1..];
+
+                    await using (var writer = getWriter())
+                    await using (var csv = config.CreateAsyncWriter(writer))
+                    {
+                        await csv.WriteAsync(range1);
+                        await csv.WriteAsync(range2);
+                    }
+
+                    var res = await getStr();
+                    Assert.Equal("2,3\r\n2,3,4", res);
+
+                    row.Dispose();
+                    range1.Dispose();
+                    range2.Dispose();
+                }
+            );
+        }
 
         [Fact]
         public async Task WriteCommentErrorsAsync()

--- a/Cesil.Tests/PublicInterfaceTests.cs
+++ b/Cesil.Tests/PublicInterfaceTests.cs
@@ -1246,7 +1246,7 @@ namespace Cesil.Tests
                     var res = csv.ReadAll();
                     var row = res[0] as DynamicRow;
 
-                    var e = new DynamicRow.DynamicColumnEnumerable(row);
+                    var e = new DynamicRow.DynamicColumnEnumerable(row, null, null);
 
                     return e.ToString();
                 }

--- a/Cesil.Tests/PublicInterfaceTests.cs
+++ b/Cesil.Tests/PublicInterfaceTests.cs
@@ -1087,6 +1087,10 @@ namespace Cesil.Tests
                 {
                     msg = InvokeToString_DefaultMemoryPoolProvider();
                 }
+                else if (t == typeof(DynamicRowRange))
+                {
+                    msg = InvokeToString_DynamicRowRange();
+                }
                 else
                 {
                     Assert.True(false, $"No test for ToString() on {t}");
@@ -1110,6 +1114,21 @@ namespace Cesil.Tests
                 if (msg2 != null)
                 {
                     Assert.StartsWith(shouldStartWith, msg2);
+                }
+            }
+
+            static string InvokeToString_DynamicRowRange()
+            {
+                var config = Configuration.ForDynamic(Options.CreateBuilder(Options.DynamicDefault).WithReadHeader(ReadHeader.Never).ToOptions());
+
+                using (var str = new StringReader("foo,bar,buzz"))
+                using (var csv = config.CreateReader(str))
+                {
+                    var res = csv.ReadAll();
+                    var row = res[0];
+                    var subRange = row[1..2];
+
+                    return (subRange as DynamicRowRange).ToString();
                 }
             }
 
@@ -1243,7 +1262,7 @@ namespace Cesil.Tests
                     var res = csv.ReadAll();
                     var row = res[0] as DynamicRow;
 
-                    using (var e = new DynamicRow.DynamicColumnEnumerator(row))
+                    using (var e = new DynamicRow.DynamicColumnEnumerator(row, null, null))
                     {
                         return e.ToString();
                     }

--- a/Cesil.Tests/WrapperTests.cs
+++ b/Cesil.Tests/WrapperTests.cs
@@ -14,6 +14,28 @@ namespace Cesil.Tests
     public class WrapperTests
     {
         [Fact]
+        public void ReadResult()
+        {
+            var a = ReadResult<object>.Empty;
+            var b = new ReadResult<object>(new object());
+
+            Assert.StartsWith(nameof(ReadResult<object>) + " ", a.ToString());
+            Assert.StartsWith(nameof(ReadResult<object>) + " ", b.ToString());
+        }
+
+        [Fact]
+        public void ReadWithCommentResult()
+        {
+            var a = ReadWithCommentResult<object>.Empty;
+            var b = new ReadWithCommentResult<object>(new object());
+            var c = new ReadWithCommentResult<object>("foo");
+
+            Assert.StartsWith(nameof(ReadWithCommentResult<object>) + " ", a.ToString());
+            Assert.StartsWith(nameof(ReadWithCommentResult<object>) + " ", b.ToString());
+            Assert.StartsWith(nameof(ReadWithCommentResult<object>) + " ", c.ToString());
+        }
+
+        [Fact]
         public void CannotChangeRowNullHandling()
         {
             var g = Getter.ForDelegate((in WriteContext _) => default(int));
@@ -4627,8 +4649,9 @@ namespace Cesil.Tests
             var ci5 = Cesil.ColumnIdentifier.Create(1, "B");
             var ci6 = Cesil.ColumnIdentifier.Create(0, "B");
             var ci7 = Cesil.ColumnIdentifier.Create(2, "C");
+            var ci8 = Cesil.ColumnIdentifier.Create(3, "F".AsMemory());
 
-            var cis = new[] { ci1, ci2, ci3, ci4, ci5, ci6, ci7 };
+            var cis = new[] { ci1, ci2, ci3, ci4, ci5, ci6, ci7, ci8 };
 
             var notCi = "";
 
@@ -4644,17 +4667,20 @@ namespace Cesil.Tests
 
                     var eq = a == b;
                     var neq = a != b;
+                    var objEq = a.Equals((object)b);
                     var hashEq = CompareHash(a, b);
 
                     if (i == j)
                     {
                         Assert.True(eq);
+                        Assert.True(objEq);
                         Assert.False(neq);
                         Assert.True(hashEq);
                     }
                     else
                     {
                         Assert.False(eq);
+                        Assert.False(objEq);
                         Assert.True(neq);
                     }
                 }
@@ -4667,6 +4693,7 @@ namespace Cesil.Tests
             Assert.Throws<ArgumentException>(() => Cesil.ColumnIdentifier.Create(-1));
 
             Assert.Throws<ArgumentException>(() => Cesil.ColumnIdentifier.Create(-1, "foo"));
+            Assert.Throws<ArgumentException>(() => Cesil.ColumnIdentifier.Create(-1, "foo".AsMemory()));
             Assert.Throws<ArgumentNullException>(() => Cesil.ColumnIdentifier.Create(10, default(string)));
 
             static bool CompareHash<T>(T a, T b)
@@ -4675,6 +4702,30 @@ namespace Cesil.Tests
 
                 return code;
             }
+        }
+
+        [Fact]
+        public void ColumnIdentifierMemory()
+        {
+            var c1 = Cesil.ColumnIdentifier.Create(1, "foo");
+            var c2 = Cesil.ColumnIdentifier.Create(1, "foo".AsMemory());
+
+            var c1Hash = c1.GetHashCode();
+            var c2Hash = c2.GetHashCode();
+
+            Assert.Equal(c1Hash, c2Hash);
+            Assert.Equal(c1, c2);
+
+            Assert.NotEmpty(c1.NameMemory.ToArray());
+            Assert.NotNull(c2.Name);
+
+            var c1HashAgain = c1.GetHashCode();
+            Assert.Equal(c1HashAgain, c1Hash);
+
+            var c2HashAgain = c2.GetHashCode();
+            Assert.Equal(c2HashAgain, c2Hash);
+
+            Assert.Equal(c1, c2);
         }
 
         [Fact]

--- a/Cesil/Common/Expressions.cs
+++ b/Cesil/Common/Expressions.cs
@@ -14,6 +14,7 @@ namespace Cesil
         internal static readonly ConstantExpression Constant_True = Expression.Constant(true);
         internal static readonly ConstantExpression Constant_False = Expression.Constant(false);
         internal static readonly ConstantExpression Constant_Null = Expression.Constant(null, Types.Object);
+        internal static readonly ConstantExpression Constant_NullInt = Expression.Constant(null, Types.NullableInt);
 
         internal static readonly ParameterExpression Variable_Bool = Expression.Variable(Types.Bool);
         internal static readonly ParameterExpression Variable_ReadOnlySpanOfChar = Expression.Variable(Types.ReadOnlySpanOfChar);

--- a/Cesil/Common/Fields.cs
+++ b/Cesil/Common/Fields.cs
@@ -17,7 +17,7 @@ namespace Cesil
 
         internal static class DynamicCell
         {
-            internal static readonly FieldInfo Row = Types.DynamicCell.GetFieldNonNull(nameof(Cesil.DynamicCell.Row), InternalInstance);
+            internal static readonly FieldInfo DependsOnDisposable = Types.DynamicCell.GetFieldNonNull(nameof(Cesil.DynamicCell.DependsOnDisposable), InternalInstance);
         }
 
         internal static class DynamicRowRange

--- a/Cesil/Common/Fields.cs
+++ b/Cesil/Common/Fields.cs
@@ -19,5 +19,12 @@ namespace Cesil
         {
             internal static readonly FieldInfo Row = Types.DynamicCell.GetFieldNonNull(nameof(Cesil.DynamicCell.Row), InternalInstance);
         }
+
+        internal static class DynamicRowRange
+        {
+            internal static readonly FieldInfo Length = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Length), InternalInstance);
+            internal static readonly FieldInfo Offset = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Offset), InternalInstance);
+            internal static readonly FieldInfo Parent = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Parent), InternalInstance);
+        }
     }
 }

--- a/Cesil/Common/Fields.cs
+++ b/Cesil/Common/Fields.cs
@@ -22,6 +22,7 @@ namespace Cesil
 
         internal static class DynamicRowRange
         {
+            internal static readonly FieldInfo Columns = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Columns), InternalInstance);
             internal static readonly FieldInfo Length = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Length), InternalInstance);
             internal static readonly FieldInfo Offset = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Offset), InternalInstance);
             internal static readonly FieldInfo Parent = Types.DynamicRowRange.GetFieldNonNull(nameof(Cesil.DynamicRowRange.Parent), InternalInstance);

--- a/Cesil/Common/Methods.cs
+++ b/Cesil/Common/Methods.cs
@@ -46,6 +46,7 @@ namespace Cesil
 
         internal static class DynamicRowRange
         {
+            internal static readonly MethodInfo Dispose = Types.DynamicRowRange.GetMethodNonNull(nameof(Cesil.DynamicRowRange.Dispose), PublicInstance);
             internal static readonly MethodInfo GetColumns = Types.DynamicRowRange.GetMethodNonNull(nameof(Cesil.DynamicRowRange.GetColumns), InternalInstance);
         }
 

--- a/Cesil/Common/Methods.cs
+++ b/Cesil/Common/Methods.cs
@@ -44,6 +44,11 @@ namespace Cesil
             internal static readonly MethodInfo Dispose = Types.DynamicRow.GetMethodNonNull(nameof(Cesil.DynamicRow.Dispose), PublicInstance);
         }
 
+        internal static class DynamicRowRange
+        {
+            internal static readonly MethodInfo GetColumns = Types.DynamicRowRange.GetMethodNonNull(nameof(Cesil.DynamicRowRange.GetColumns), InternalInstance);
+        }
+
         internal static class IDynamicRowOwner
         {
             internal static readonly MethodInfo Options = Types.IDynamicRowOwner.GetPropertyNonNull(nameof(Cesil.IDynamicRowOwner.Options), PublicInstance).GetGetMethodNonNull();

--- a/Cesil/Common/Methods.cs
+++ b/Cesil/Common/Methods.cs
@@ -47,7 +47,6 @@ namespace Cesil
         internal static class DynamicRowRange
         {
             internal static readonly MethodInfo Dispose = Types.DynamicRowRange.GetMethodNonNull(nameof(Cesil.DynamicRowRange.Dispose), PublicInstance);
-            internal static readonly MethodInfo GetColumns = Types.DynamicRowRange.GetMethodNonNull(nameof(Cesil.DynamicRowRange.GetColumns), InternalInstance);
         }
 
         internal static class IDynamicRowOwner

--- a/Cesil/Common/Types.cs
+++ b/Cesil/Common/Types.cs
@@ -44,6 +44,7 @@ namespace Cesil
                 typeof(ValueTuple<,,,,,,,>).GetTypeInfo()
            };
         internal static readonly TypeInfo ReadOnlySpanOfChar = typeof(ReadOnlySpan<char>).GetTypeInfo();
+        internal static readonly TypeInfo NullableInt = typeof(int?).GetTypeInfo();
 
         // System classes
         internal static readonly TypeInfo Object = typeof(object).GetTypeInfo();
@@ -170,9 +171,10 @@ namespace Cesil
         internal static readonly TypeInfo DynamicRow = typeof(DynamicRow).GetTypeInfo();
         internal static readonly TypeInfo DynamicRowEnumerable = typeof(DynamicRowEnumerable<>).GetTypeInfo();
         internal static readonly TypeInfo DynamicRowEnumerableNonGeneric = typeof(DynamicRowEnumerableNonGeneric).GetTypeInfo();
+        internal static readonly TypeInfo DynamicRowRange = typeof(DynamicRowRange).GetTypeInfo();
         internal static readonly TypeInfo PassthroughRowEnumerable = typeof(PassthroughRowEnumerable).GetTypeInfo();
         internal static readonly TypeInfo DefaultTypeDescriber = typeof(DefaultTypeDescriber).GetTypeInfo();
-
+        
         // constructor params
         internal static readonly TypeInfo[] ParserConstructorOneParameter_Array = new[] { typeof(ReadOnlySpan<char>).GetTypeInfo() };
         internal static readonly TypeInfo[] ParserConstructorTwoParameter_Array = new[] { typeof(ReadOnlySpan<char>).GetTypeInfo(), typeof(ReadContext).MakeByRefType().GetTypeInfo() };

--- a/Cesil/Reader/Dynamic/AsyncDynamicReader.cs
+++ b/Cesil/Reader/Dynamic/AsyncDynamicReader.cs
@@ -438,6 +438,7 @@ namespace Cesil
             while (NotifyOnDisposeHead != null)
             {
                 NotifyOnDisposeHead.Dispose();
+                NotifyOnDisposeHead.TryDataDispose(force: true);
                 NotifyOnDisposeHead.Remove(ref NotifyOnDisposeHead, NotifyOnDisposeHead);
             }
 

--- a/Cesil/Reader/Dynamic/DynamicCell.cs
+++ b/Cesil/Reader/Dynamic/DynamicCell.cs
@@ -107,13 +107,11 @@ namespace Cesil
             var byteConf = describer.GetDynamicCellParserFor(in ctx, Types.Byte);
             var charConf = describer.GetDynamicCellParserFor(in ctx, Types.Char);
             var dtConf = describer.GetDynamicCellParserFor(in ctx, Types.DateTime);
-            //var decConf = describer.GetDynamicCellParserFor(in ctx, Types.DecimalType);
             var doubleConf = describer.GetDynamicCellParserFor(in ctx, Types.Double);
             var shortConf = describer.GetDynamicCellParserFor(in ctx, Types.Short);
             var intConf = describer.GetDynamicCellParserFor(in ctx, Types.Int);
             var longConf = describer.GetDynamicCellParserFor(in ctx, Types.Long);
             var sbyteConf = describer.GetDynamicCellParserFor(in ctx, Types.SByte);
-            //var floatConf = describer.GetDynamicCellParserFor(in ctx, Types.FloatType);
             var stringConf = describer.GetDynamicCellParserFor(in ctx, Types.String);
             var ushortConf = describer.GetDynamicCellParserFor(in ctx, Types.UShort);
             var uintConf = describer.GetDynamicCellParserFor(in ctx, Types.UInt);

--- a/Cesil/Reader/Dynamic/DynamicCell.cs
+++ b/Cesil/Reader/Dynamic/DynamicCell.cs
@@ -10,13 +10,15 @@ namespace Cesil
         internal readonly uint Generation;
         internal readonly DynamicRow Row;
         internal readonly int ColumnNumber;
+        internal readonly ITestableDisposable DependsOnDisposable;
 
         internal ITypeDescriber Converter => Row.Converter;
 
-        internal DynamicCell(DynamicRow row, int num)
+        internal DynamicCell(DynamicRow row, ITestableDisposable disposable, int num)
         {
             Row = row;
             Generation = row.Generation;
+            DependsOnDisposable = disposable;
             ColumnNumber = num;
         }
 
@@ -64,7 +66,7 @@ namespace Cesil
 
         internal Parser? GetParser(TypeInfo forType, out ReadContext ctx)
         {
-            var row = Row;
+            var row = SafeRowGet();
             var owner = row.Owner;
             var index = ColumnNumber;
             var converterInterface = Converter;
@@ -85,7 +87,7 @@ namespace Cesil
             var ret = Row;
             ret.AssertGenerationMatch(Generation);
 
-            DisposableHelper.AssertNotDisposedInternal(ret);
+            // not checking disposal here as it could be accessed, post visible disposal, via a DynamicRowRange
 
             return ret;
         }

--- a/Cesil/Reader/Dynamic/DynamicCellMetaObject.cs
+++ b/Cesil/Reader/Dynamic/DynamicCellMetaObject.cs
@@ -100,7 +100,6 @@ namespace Cesil
             var parserExp = parser.MakeExpression(dataSpanVar, readCtxVar, outVar);
             var assignRes = Expression.Assign(resVar, parserExp);
 
-
             statements.Add(assignRes);
 
             var invalidCallOp = Methods.Throw.InvalidOperationExceptionOfObject;
@@ -119,9 +118,8 @@ namespace Cesil
 
         private static Expression MakeAssertNotDisposedExpression(Expression exp)
         {
-            var row = Expression.Field(exp, Fields.DynamicCell.Row);
-            var cast = Expression.Convert(row, Types.ITestableDisposable);
-            var call = Expression.Call(Methods.DisposableHelper.AssertNotDisposed, cast);
+            var dependsOn = Expression.Field(exp, Fields.DynamicCell.DependsOnDisposable);
+            var call = Expression.Call(Methods.DisposableHelper.AssertNotDisposed, dependsOn);
 
             return call;
         }

--- a/Cesil/Reader/Dynamic/DynamicExpressionHelper.cs
+++ b/Cesil/Reader/Dynamic/DynamicExpressionHelper.cs
@@ -1,0 +1,259 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Cesil
+{
+    internal static class DynamicExpressionHelper
+    {
+        internal static DynamicMetaObject BindGetIndexFor(
+            BindingRestrictions restrictions,
+            Expression expression,
+            Expression testableDisposable,
+            GetIndexBinder _,
+            DynamicMetaObject[] indexes,
+            Expression? offset,
+            Expression? length
+        )
+        {
+            if (indexes.Length != 1)
+            {
+                var msg = Expression.Constant($"Only single indexers are supported.");
+                var invalidOpCall = Methods.Throw.InvalidOperationExceptionOfObject;
+                var call = Expression.Call(invalidOpCall, msg);
+
+                // we can cache this forever (for this type), since there's no scenario under which indexes != 1 becomes correct
+                return new DynamicMetaObject(call, restrictions);
+            }
+
+            var assertNotDisposed = MakeAssertNotDisposedExpression(testableDisposable);
+
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
+
+            var indexExp = indexes[0].Expression;
+            var indexType = indexes[0].RuntimeType.GetTypeInfo();
+
+            if (indexType == Types.Int)
+            {
+                var indexExpressionIsIntRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Int);
+
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
+
+                var index = Expression.Convert(indexExp, Types.Int);
+
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetAt, index, testableDisposable, offsetVar, lengthVar);
+
+                var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+                var finalRestrictions = restrictions.Merge(indexExpressionIsIntRestriction);
+                return new DynamicMetaObject(block, finalRestrictions);
+            }
+
+            if (indexType == Types.String)
+            {
+                var indexExpressionIsStringRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.String);
+
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
+
+                var col = Expression.Convert(indexExp, Types.String);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, col, testableDisposable, offsetVar, lengthVar);
+
+                var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+                var finalRestrictions = restrictions.Merge(indexExpressionIsStringRestriction);
+                return new DynamicMetaObject(block, finalRestrictions);
+            }
+
+            if (indexType == Types.Index)
+            {
+                var indexExpressionIsIndexRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Index);
+
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
+
+                var col = Expression.Convert(indexExp, Types.Index);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIndex, col, testableDisposable, offsetVar, lengthVar);
+
+                var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+                var finalRestrictions = restrictions.Merge(indexExpressionIsIndexRestriction);
+                return new DynamicMetaObject(block, finalRestrictions);
+            }
+
+            if (indexType == Types.Range)
+            {
+                var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Range);
+
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
+
+                var range = Expression.Convert(indexExp, Types.Range);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetRange, range, offsetVar, lengthVar);
+
+                var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
+                return new DynamicMetaObject(block, finalRestrictions);
+            }
+
+            if (indexType == Types.ColumnIdentifier)
+            {
+                var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.ColumnIdentifier);
+
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
+
+                var colId = Expression.Convert(indexExp, Types.ColumnIdentifier);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIdentifier, colId, testableDisposable, offsetVar, lengthVar);
+
+                var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
+                return new DynamicMetaObject(block, finalRestrictions);
+            }
+
+            // no binder
+            {
+                var msg = Expression.Constant($"Only string, int, Index, and Range indexers are supported.");
+                var invalidOpCall = Methods.Throw.InvalidOperationExceptionOfObject;
+                var call = Expression.Call(invalidOpCall, msg);
+
+                // we can cache this forever (for this type), since there's no scenario under which incorrect index types become correct
+                return new DynamicMetaObject(call, restrictions);
+            }
+        }
+
+        internal static DynamicMetaObject BindGetMemberFor(
+            BindingRestrictions restrictions,
+            Expression expression,
+            Expression iTestableDisposable,
+            GetMemberBinder binder,
+            Expression? offset,
+            Expression? length
+        )
+        {
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
+
+            var assertNotDisposed = MakeAssertNotDisposedExpression(iTestableDisposable);
+
+            var name = Expression.Constant(binder.Name);
+            var castToRow = Expression.Convert(expression, Types.DynamicRow);
+            var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, name, iTestableDisposable, offsetVar, lengthVar);
+
+            var block = Expression.Block(assertNotDisposed, callOnSelf);
+
+            return new DynamicMetaObject(block, restrictions);
+        }
+
+        internal static BindingRestrictions MakeRestrictions(TypeInfo rowType, Expression expression, DynamicRowConverter? expected, Expression getDynamicRow, Expression getColumns, TypeInfo returnType)
+        {
+            var expectedConst = Expression.Constant(expected);
+            var get = GetRowConverter(getDynamicRow, getColumns, returnType);
+            var eq = Expression.Equal(expectedConst, get);
+
+            var sameConverterRestriction = BindingRestrictions.GetExpressionRestriction(eq);
+
+            var expressionIsRowRestriction = BindingRestrictions.GetTypeRestriction(expression, rowType);
+
+            var ret = expressionIsRowRestriction.Merge(sameConverterRestriction);
+
+            return ret;
+
+            // create an expression that will obtain the current DynamicRowConverter for the DynamicRow obtained from the given expression
+            static Expression GetRowConverter(Expression getDynamicRow, Expression getColumns, TypeInfo forType)
+            {
+                var typeConst = Expression.Constant(forType);
+                var converter = Expression.Field(getDynamicRow, Fields.DynamicRow.Converter);
+                var rowNumber = Expression.Field(getDynamicRow, Fields.DynamicRow.RowNumber);
+                var context = Expression.Field(getDynamicRow, Fields.DynamicRow.Context);
+                var owner = Expression.Field(getDynamicRow, Fields.DynamicRow.Owner);
+                var options = Expression.Call(owner, Methods.IDynamicRowOwner.Options);
+
+                var getCtx = Expression.Call(Methods.ReadContext.ConvertingRow, options, rowNumber, context);
+
+                var dynamicRowConverter = Expression.Call(converter, Methods.ITypeDescriber.GetDynamicRowConverter, getCtx, getColumns, typeConst);
+
+                return dynamicRowConverter;
+            }
+        }
+
+        internal static DynamicMetaObject BindConvertFor(
+            BindingRestrictions restrictions,
+            Expression callSiteExpression,   // this needs to be either DynamicRow or DynamicRowRange typed
+            Expression dynamicRowExpression, // must be DynamicRow type
+            MethodCallExpression assertNotDisposed,
+            DynamicRow row,
+            TypeInfo retType,
+            DynamicRowConverter? converter,
+            Expression? offset,
+            Expression? length
+        )
+        {
+            // special case, converting to IDisposable will ALWAYS succeed
+            //   because every dynamic row supports disposal
+            if (retType == Types.IDisposable)
+            {
+                var cast = Expression.Convert(callSiteExpression, Types.IDisposable);
+
+                // intentionally NOT checking if the row is already disposed
+                return new DynamicMetaObject(cast, restrictions);
+            }
+
+            if (converter == null)
+            {
+                var invalidOpCall = Methods.Throw.InvalidOperationException.MakeGenericMethod(retType);
+                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"No row converter discovered for {retType}"));
+
+                return new DynamicMetaObject(throwMsg, restrictions);
+            }
+
+            if (!retType.IsAssignableFrom(converter.TargetType))
+            {
+                var invalidOpCall = Methods.Throw.InvalidOperationException.MakeGenericMethod(retType);
+                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"Row converter {converter} does not create a type assignable to {retType}, returns {converter.TargetType}"));
+
+                return new DynamicMetaObject(throwMsg, restrictions);
+            }
+
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
+
+            var statements = new List<Expression>();
+            statements.Add(assertNotDisposed);
+
+            var dynRowVar = Expressions.Variable_DynamicRow;
+            var assignDynRow = Expression.Assign(dynRowVar, dynamicRowExpression);
+            statements.Add(assignDynRow);
+
+            var outArg = Expression.Variable(retType);
+
+            var callGetContext = Expression.Call(dynRowVar, Methods.DynamicRow.GetReadContext, offsetVar, lengthVar);
+            var readCtxVar = Expressions.Variable_ReadContext;
+            var assignReadCtx = Expression.Assign(readCtxVar, callGetContext);
+            statements.Add(assignReadCtx);
+
+            var expressionVar = Expression.Variable(callSiteExpression.Type.GetTypeInfo());
+            var assignExpressionVar = Expression.Assign(expressionVar, callSiteExpression);
+            statements.Add(assignExpressionVar);
+            var convertExp = converter.MakeExpression(retType, expressionVar, readCtxVar, outArg);
+
+            var errorMsg = Expression.Constant($"{nameof(DynamicRowConverter)} ({converter}) could not convert dynamic row to {retType}");
+            var throwInvalidOp = Expression.Call(Methods.Throw.InvalidOperationExceptionOfObject, errorMsg);
+
+            var ifFalseThrow = Expression.IfThen(Expression.Not(convertExp), throwInvalidOp);
+            statements.Add(ifFalseThrow);
+            statements.Add(outArg);
+
+            var block = Expression.Block(new[] { outArg, dynRowVar, readCtxVar, expressionVar }, statements);
+
+            return new DynamicMetaObject(block, restrictions);
+        }
+
+        internal static MethodCallExpression MakeAssertNotDisposedExpression(Expression exp)
+        {
+            var call = Expression.Call(Methods.DisposableHelper.AssertNotDisposed, exp);
+
+            return call;
+        }
+    }
+}

--- a/Cesil/Reader/Dynamic/DynamicReader.cs
+++ b/Cesil/Reader/Dynamic/DynamicReader.cs
@@ -204,6 +204,7 @@ namespace Cesil
             while (NotifyOnDisposeHead != null)
             {
                 NotifyOnDisposeHead.Dispose();
+                NotifyOnDisposeHead.TryDataDispose(force: true);
                 NotifyOnDisposeHead.Remove(ref NotifyOnDisposeHead, NotifyOnDisposeHead);
             }
 

--- a/Cesil/Reader/Dynamic/DynamicRow.cs
+++ b/Cesil/Reader/Dynamic/DynamicRow.cs
@@ -19,6 +19,8 @@ namespace Cesil
             private int NextIndex;
 
             private readonly uint ExpectedGeneration;
+            private readonly int? Offset;
+            private readonly int? Length;
 
             private ColumnIdentifier _Current;
             public ColumnIdentifier Current
@@ -36,10 +38,13 @@ namespace Cesil
 
             public bool IsDisposed { get; private set; }
 
-            internal DynamicColumnEnumerator(DynamicRow row)
+            internal DynamicColumnEnumerator(DynamicRow row, int? offset, int? length)
             {
                 Row = row;
                 ExpectedGeneration = row.Generation;
+
+                Offset = offset;
+                Length = length;
 
                 Reset();
             }
@@ -49,12 +54,17 @@ namespace Cesil
                 AssertNotDisposed(this);
                 Row.AssertGenerationMatch(ExpectedGeneration);
 
+                var trueWidth = Length ?? Row.Width;
+
                 var ix = NextIndex;
-                if (ix < Row.Width)
+                if (ix < trueWidth)
                 {
+                    var trueIx = ix;
+                    trueIx += Offset ?? 0;
+
                     if (Row.HasNames)
                     {
-                        var name = Row.Names[ix];
+                        var name = Row.Names[trueIx];
                         _Current = ColumnIdentifier.CreateInner(ix, name, null);
                     }
                     else
@@ -122,7 +132,7 @@ namespace Cesil
             }
 
             public IEnumerator<ColumnIdentifier> GetEnumerator()
-            => new DynamicColumnEnumerator(Row);
+            => new DynamicColumnEnumerator(Row, null, null);
 
             [ExcludeFromCoverage("Trivial, and covered by IEnumerable<T>.GetEnumerator()")]
             IEnumerator IEnumerable.GetEnumerator()
@@ -355,33 +365,33 @@ checkSize:
             return true;
         }
 
-        internal object? GetAt(int index)
+        internal object? GetAt(int index, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
-            if (!TryGetIndex(index, out var ret))
+            if (!TryGetIndex(index, out var ret, offset, length))
             {
-                return Throw.ArgumentOutOfRangeException<object>(nameof(index), index, Width);
+                return Throw.ArgumentOutOfRangeException<object>(nameof(index), index, length ?? Width);
             }
 
             return ret;
         }
 
-        internal object? GetByIndex(Index index)
+        internal object? GetByIndex(Index index, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
             int actualIndex;
             if (index.IsFromEnd)
             {
-                actualIndex = Width - index.Value;
+                actualIndex = (length ?? Width) - index.Value;
             }
             else
             {
                 actualIndex = index.Value;
             }
 
-            if (!TryGetIndex(actualIndex, out var ret))
+            if (!TryGetIndex(actualIndex, out var ret, offset, length))
             {
                 return Throw.ArgumentOutOfRangeException<object>(nameof(index), index, actualIndex, Width);
             }
@@ -389,24 +399,24 @@ checkSize:
             return ret;
         }
 
-        internal T GetAtTyped<T>(in ColumnIdentifier index)
+        internal T GetAtTyped<T>(in ColumnIdentifier index, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
-            dynamic? toCast = GetByIdentifier(in index);
+            dynamic? toCast = GetByIdentifier(in index, offset, length);
 
 #pragma warning disable CES0005 // T is generic, so we can't annotate it (could be a class or struct) but we want dynamic to try and convert regardless
             return (T)toCast!;
 #pragma warning restore CES0005
         }
 
-        internal object? GetByIdentifier(in ColumnIdentifier index)
+        internal object? GetByIdentifier(in ColumnIdentifier index, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
             if (index.HasName && HasNames)
             {
-                if (TryGetValue(index.Name, out var res))
+                if (TryGetValue(index.Name, out var res, offset, length))
                 {
                     return res;
                 }
@@ -415,20 +425,20 @@ checkSize:
             }
             else
             {
-                if (TryGetIndex(index.Index, out var res))
+                if (TryGetIndex(index.Index, out var res, offset, length))
                 {
                     return res;
                 }
 
-                return Throw.ArgumentOutOfRangeException<object>(nameof(index), index.Index, Width);
+                return Throw.ArgumentOutOfRangeException<object>(nameof(index), index.Index, length ?? Width);
             }
         }
 
-        internal object? GetByName(string column)
+        internal object? GetByName(string column, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
-            if (!TryGetValue(column, out var ret))
+            if (!TryGetValue(column, out var ret, offset, length))
             {
                 return Throw.KeyNotFoundException<object>(column);
             }
@@ -449,11 +459,13 @@ checkSize:
             return new DynamicCell(this, ix);
         }
 
-        internal DynamicRow GetRange(Range range)
+        internal DynamicRowRange GetRange(Range range, int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
-            string[]? names;
+            var actualStart = offset ?? 0;
+            var actualWidth = length ?? Width;
+            var actualEnd = actualStart + actualWidth;
 
             var startIndex = range.Start;
             var endIndex = range.End;
@@ -463,94 +475,39 @@ checkSize:
 
             if (startIndex.IsFromEnd)
             {
-                rawStart = Width - startIndex.Value;
+                rawStart = actualEnd - startIndex.Value;
             }
             else
             {
-                rawStart = startIndex.Value;
+                rawStart = actualStart + startIndex.Value;
             }
 
             if (endIndex.IsFromEnd)
             {
-                rawEnd = Width - endIndex.Value;
+                rawEnd = actualEnd - endIndex.Value;
             }
             else
             {
-                rawEnd = endIndex.Value;
+                rawEnd = actualStart + endIndex.Value;
             }
 
-            if (rawStart < 0 || rawStart > Width || rawEnd < 0 || rawEnd > Width)
+            if (rawStart < actualStart || rawStart > actualEnd || rawEnd < actualStart || rawEnd > actualEnd)
             {
-                return Throw.ArgumentOutOfRangeException<DynamicRow>(nameof(range), range, rawStart, rawEnd, Width);
+                return Throw.ArgumentOutOfRangeException<DynamicRowRange>(nameof(range), range, actualStart, actualEnd, actualWidth);
             }
 
             if (rawStart > rawEnd)
             {
-                return Throw.ArgumentException<DynamicRow>($"Start of range ({rawStart}) greater than end of range ({rawEnd}) in {range}", nameof(range));
+                return Throw.ArgumentException<DynamicRowRange>($"Start of range ({rawStart}) greater than end of range ({rawEnd}) in {range}", nameof(range));
             }
 
             var width = rawEnd - rawStart;
 
-            var newRow = new DynamicRow();
-            if (HasNames)
-            {
-                if (width == 0)
-                {
-                    names = Array.Empty<string>();
-                }
-                else
-                {
-                    var namesValue = Names;
-
-                    names = new string[width];
-
-                    var readFrom = rawStart;
-                    for (var writeTo = 0; writeTo < width; writeTo++)
-                    {
-                        var val = namesValue[readFrom];
-                        names[writeTo] = val;
-                        readFrom++;
-                    }
-                }
-            }
-            else
-            {
-                names = null;
-            }
-
-            newRow.Init(Owner, RowNumber, Context, Converter, HasNames, names, NamesIndexOffset - rawStart, MemoryPool);
-
-            // todo: it would be _nice_ to avoid a copy here (tracking issue: https://github.com/kevin-montrose/Cesil/issues/9)
-            //   we might be able to, if we are informed when THIS
-            //   row is being disposed
-            //
-            // as it is now...
-            //   we have to copy because otherwise re-using the base row
-            //   might change the subset... and might make it invalid, even!
-            var copyFrom = rawStart;
-            for (var writeTo = 0; writeTo < width; writeTo++)
-            {
-                if (TryGetDataSpan(copyFrom, out var span))
-                {
-                    newRow.SetValue(writeTo, span);
-                }
-                else
-                {
-                    newRow.SetNull(writeTo);
-                }
-                copyFrom++;
-            }
-
-            if (HasOwner)
-            {
-                // by definition, the new row won't be the head, so we can skip the tricks needed for an empty list
-                this.AddAfter(newRow);
-            }
-
-            return newRow;
+            // todo: track this for disposal purposes
+            return new DynamicRowRange(this, rawStart, width);
         }
 
-        internal ReadContext GetReadContext()
+        internal ReadContext GetReadContext(int? offset, int? length)
         {
             AssertNotDisposedInternal(this);
 
@@ -559,32 +516,50 @@ checkSize:
             return ReadContext.ConvertingRow(owner.Options, RowNumber, owner.Context);
         }
 
-        private bool TryGetIndex(int index, out object? result)
+        private bool TryGetIndex(int index, out object? result, int? offset, int? length)
         {
-            var maxWidth = Width;
-
-            if (index < 0 || index >= maxWidth)
+            if (offset.HasValue && length.HasValue && index >= length.Value)
             {
                 result = null;
                 return false;
             }
 
-            if (!IsSet(index))
+            var actualStart = offset ?? 0;
+
+            var actualIndex = index + actualStart;
+
+            if (actualIndex < actualStart || actualIndex >= Width)
+            {
+                result = null;
+                return false;
+            }
+
+            if (!IsSet(actualIndex))
             {
                 result = null;
                 return true;
             }
 
-            result = GetCellAt(index);
+            result = GetCellAt(actualIndex);
             return true;
         }
 
-        private bool TryGetValue(string lookingFor, out object? result)
+        private bool TryGetValue(string lookingFor, out object? result, int? offset, int? length)
         {
             if (HasNames)
             {
                 if (NameLookup.TryLookup(lookingFor, out var index))
                 {
+                    // only need to check that we can actually find it, the true offset is fine for fetching
+                    if (offset.HasValue && length.HasValue)
+                    {
+                        if (index < offset.Value || index >= (offset.Value + length.Value))
+                        {
+                            result = null;
+                            return false;
+                        }
+                    }
+
                     // we might be in a row fetched by GetRange
                     //   in which case _our_ index is a bit different from
                     //   the outer index

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerable.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerable.cs
@@ -8,6 +8,7 @@ namespace Cesil
     {
         private readonly uint Generation;
         private readonly DynamicRow Row;
+        private readonly ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
@@ -16,17 +17,19 @@ namespace Cesil
             if (row is DynamicRow dynRow)
             {
                 Row = dynRow;
+                DependsOn = dynRow;
                 Offset = Length = null;
             }
             else if (row is DynamicRowRange dynRowRange)
             {
                 Row = dynRowRange.Parent;
+                DependsOn = dynRowRange;
                 Offset = dynRowRange.Offset;
                 Length = dynRowRange.Length;
             }
             else
             {
-                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+                DependsOn = Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
             }
 
             Generation = Row.Generation;
@@ -36,7 +39,7 @@ namespace Cesil
         {
             Row.AssertGenerationMatch(Generation);
 
-            return new DynamicRowEnumerator<T>(Row, Offset, Length);
+            return new DynamicRowEnumerator<T>(Row, DependsOn, Offset, Length);
         }
 
         [ExcludeFromCoverage("Trivial, and covered by IEnumerable<T>.GetEnumerator()")]

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerable.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerable.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Cesil
 {
@@ -7,10 +8,27 @@ namespace Cesil
     {
         private readonly uint Generation;
         private readonly DynamicRow Row;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         internal DynamicRowEnumerable(object row)
         {
-            Row = (DynamicRow)row;
+            if (row is DynamicRow dynRow)
+            {
+                Row = dynRow;
+                Offset = Length = null;
+            }
+            else if (row is DynamicRowRange dynRowRange)
+            {
+                Row = dynRowRange.Parent;
+                Offset = dynRowRange.Offset;
+                Length = dynRowRange.Length;
+            }
+            else
+            {
+                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+            }
+
             Generation = Row.Generation;
         }
 
@@ -18,7 +36,7 @@ namespace Cesil
         {
             Row.AssertGenerationMatch(Generation);
 
-            return new DynamicRowEnumerator<T>(Row);
+            return new DynamicRowEnumerator<T>(Row, Offset, Length);
         }
 
         [ExcludeFromCoverage("Trivial, and covered by IEnumerable<T>.GetEnumerator()")]

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerableNonGeneric.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerableNonGeneric.cs
@@ -7,6 +7,7 @@ namespace Cesil
     internal sealed class DynamicRowEnumerableNonGeneric : IEnumerable
     {
         private readonly DynamicRow Row;
+        private readonly ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
@@ -15,17 +16,19 @@ namespace Cesil
             if (row is DynamicRow dynRow)
             {
                 Row = dynRow;
+                DependsOn = dynRow;
                 Offset = Length = null;
             }
             else if (row is DynamicRowRange dynRowRange)
             {
                 Row = dynRowRange.Parent;
+                DependsOn = dynRowRange;
                 Offset = dynRowRange.Offset;
                 Length = dynRowRange.Length;
             }
             else
             {
-                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+                DependsOn = Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
                 return;
             }
         }
@@ -34,7 +37,7 @@ namespace Cesil
         {
             AssertNotDisposed(Row);
 
-            return new DynamicRowEnumeratorNonGeneric(Row, Offset, Length);
+            return new DynamicRowEnumeratorNonGeneric(Row, DependsOn, Offset, Length);
         }
 
         public override string ToString()

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerableNonGeneric.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerableNonGeneric.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections;
-
+using System.Reflection;
 using static Cesil.DisposableHelper;
 
 namespace Cesil
@@ -7,17 +7,34 @@ namespace Cesil
     internal sealed class DynamicRowEnumerableNonGeneric : IEnumerable
     {
         private readonly DynamicRow Row;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         internal DynamicRowEnumerableNonGeneric(object row)
         {
-            Row = (DynamicRow)row;
+            if (row is DynamicRow dynRow)
+            {
+                Row = dynRow;
+                Offset = Length = null;
+            }
+            else if (row is DynamicRowRange dynRowRange)
+            {
+                Row = dynRowRange.Parent;
+                Offset = dynRowRange.Offset;
+                Length = dynRowRange.Length;
+            }
+            else
+            {
+                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+                return;
+            }
         }
 
         public IEnumerator GetEnumerator()
         {
             AssertNotDisposed(Row);
 
-            return new DynamicRowEnumeratorNonGeneric(Row);
+            return new DynamicRowEnumeratorNonGeneric(Row, Offset, Length);
         }
 
         public override string ToString()

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerator.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerator.cs
@@ -10,6 +10,8 @@ namespace Cesil
         // this checks that reusing the underlying DynamicRow will
         //   cause a generation check failure
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         public bool IsDisposed => Enumerator.IsDisposed;
 
@@ -26,12 +28,14 @@ namespace Cesil
         [ExcludeFromCoverage("Trivial, and covered by IEnumerator<T>.Current")]
         object? IEnumerator.Current => Current;
 
-        internal DynamicRowEnumerator(DynamicRow row)
+        internal DynamicRowEnumerator(DynamicRow row, int? offset, int? length)
         {
 #pragma warning disable CES0005 // T is generic, and we'll overwrite it before it's used, so default! is needed
             _Current = default!;
 #pragma warning restore CES0005
-            Enumerator = new DynamicRow.DynamicColumnEnumerator(row);
+            Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            Offset = offset;
+            Length = length;
         }
 
         public bool MoveNext()
@@ -45,7 +49,9 @@ namespace Cesil
 
             var col = Enumerator.Current;
 
-            var val = Enumerator.Row.GetCellAt(col.Index);
+            var trueIx = col.Index + (Offset ?? 0);
+
+            var val = Enumerator.Row.GetCellAt(trueIx);
             if (val == null)
             {
 #pragma warning disable CES0005 // empty value needs to be mapped to whatever default is for T, which may well be null, but we can't annotate T because it could be anything

--- a/Cesil/Reader/Dynamic/DynamicRowEnumerator.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumerator.cs
@@ -10,6 +10,7 @@ namespace Cesil
         // this checks that reusing the underlying DynamicRow will
         //   cause a generation check failure
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        private readonly ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
@@ -28,12 +29,13 @@ namespace Cesil
         [ExcludeFromCoverage("Trivial, and covered by IEnumerator<T>.Current")]
         object? IEnumerator.Current => Current;
 
-        internal DynamicRowEnumerator(DynamicRow row, int? offset, int? length)
+        internal DynamicRowEnumerator(DynamicRow row, ITestableDisposable dependsOn, int? offset, int? length)
         {
 #pragma warning disable CES0005 // T is generic, and we'll overwrite it before it's used, so default! is needed
             _Current = default!;
 #pragma warning restore CES0005
             Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            DependsOn = dependsOn;
             Offset = offset;
             Length = length;
         }
@@ -51,7 +53,7 @@ namespace Cesil
 
             var trueIx = col.Index + (Offset ?? 0);
 
-            var val = Enumerator.Row.GetCellAt(trueIx);
+            var val = Enumerator.Row.GetCellAt(DependsOn, trueIx);
             if (val == null)
             {
 #pragma warning disable CES0005 // empty value needs to be mapped to whatever default is for T, which may well be null, but we can't annotate T because it could be anything

--- a/Cesil/Reader/Dynamic/DynamicRowEnumeratorNonGeneric.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumeratorNonGeneric.cs
@@ -5,14 +5,16 @@ namespace Cesil
     internal sealed class DynamicRowEnumeratorNonGeneric : IEnumerator
     {
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        private readonly ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
         public object? Current { get; private set; }
 
-        internal DynamicRowEnumeratorNonGeneric(DynamicRow row, int? offset, int? length)
+        internal DynamicRowEnumeratorNonGeneric(DynamicRow row, ITestableDisposable dependsOn, int? offset, int? length)
         {
             Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            DependsOn = dependsOn;
             Offset = offset;
             Length = length;
         }
@@ -29,7 +31,7 @@ namespace Cesil
 
             var trueIx = col.Index + (Offset ?? 0);
 
-            Current = Enumerator.Row.GetCellAt(trueIx);
+            Current = Enumerator.Row.GetCellAt(DependsOn, trueIx);
 
             return true;
         }

--- a/Cesil/Reader/Dynamic/DynamicRowEnumeratorNonGeneric.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowEnumeratorNonGeneric.cs
@@ -5,12 +5,16 @@ namespace Cesil
     internal sealed class DynamicRowEnumeratorNonGeneric : IEnumerator
     {
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         public object? Current { get; private set; }
 
-        internal DynamicRowEnumeratorNonGeneric(DynamicRow row)
+        internal DynamicRowEnumeratorNonGeneric(DynamicRow row, int? offset, int? length)
         {
-            Enumerator = new DynamicRow.DynamicColumnEnumerator(row);
+            Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            Offset = offset;
+            Length = length;
         }
 
         public bool MoveNext()
@@ -23,7 +27,9 @@ namespace Cesil
 
             var col = Enumerator.Current;
 
-            Current = Enumerator.Row.GetCellAt(col.Index);
+            var trueIx = col.Index + (Offset ?? 0);
+
+            Current = Enumerator.Row.GetCellAt(trueIx);
 
             return true;
         }

--- a/Cesil/Reader/Dynamic/DynamicRowMetaObject.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowMetaObject.cs
@@ -63,124 +63,7 @@ namespace Cesil
             var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
             var selfAsITestableDisposable = Expression.Convert(Expression, Types.ITestableDisposable);
 
-            return BindGetIndexFor(restrictions, Expression, selfAsITestableDisposable, binder, indexes, null, null);
-        }
-
-        // todo: maybe move this to some common place?
-        internal static DynamicMetaObject BindGetIndexFor(
-            BindingRestrictions restrictions,
-            Expression expression, 
-            Expression testableDisposable,
-            //MethodCallExpression assertNotDisposed,
-            GetIndexBinder _, 
-            DynamicMetaObject[] indexes, 
-            Expression? offset, 
-            Expression? length
-        )
-        {
-            if (indexes.Length != 1)
-            {
-                var msg = Expression.Constant($"Only single indexers are supported.");
-                var invalidOpCall = Methods.Throw.InvalidOperationExceptionOfObject;
-                var call = Expression.Call(invalidOpCall, msg);
-
-                // we can cache this forever (for this type), since there's no scenario under which indexes != 1 becomes correct
-                return new DynamicMetaObject(call, restrictions);
-            }
-
-            var assertNotDisposed = MakeAssertNotDisposedExpression(testableDisposable);
-
-            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
-            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
-
-            var indexExp = indexes[0].Expression;
-            var indexType = indexes[0].RuntimeType.GetTypeInfo();
-
-            if (indexType == Types.Int)
-            {
-                var indexExpressionIsIntRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Int);
-
-                var castToRow = Expression.Convert(expression, Types.DynamicRow);
-
-                var index = Expression.Convert(indexExp, Types.Int);
-                
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetAt, index, testableDisposable, offsetVar, lengthVar);
-
-                var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-                var finalRestrictions = restrictions.Merge(indexExpressionIsIntRestriction);
-                return new DynamicMetaObject(block, finalRestrictions);
-            }
-
-            if (indexType == Types.String)
-            {
-                var indexExpressionIsStringRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.String);
-
-                var castToRow = Expression.Convert(expression, Types.DynamicRow);
-
-                var col = Expression.Convert(indexExp, Types.String);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, col, testableDisposable, offsetVar, lengthVar);
-
-                var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-                var finalRestrictions = restrictions.Merge(indexExpressionIsStringRestriction);
-                return new DynamicMetaObject(block, finalRestrictions);
-            }
-
-            if (indexType == Types.Index)
-            {
-                var indexExpressionIsIndexRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Index);
-
-                var castToRow = Expression.Convert(expression, Types.DynamicRow);
-
-                var col = Expression.Convert(indexExp, Types.Index);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIndex, col, testableDisposable, offsetVar, lengthVar);
-
-                var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-                var finalRestrictions = restrictions.Merge(indexExpressionIsIndexRestriction);
-                return new DynamicMetaObject(block, finalRestrictions);
-            }
-
-            if (indexType == Types.Range)
-            {
-                var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Range);
-
-                var castToRow = Expression.Convert(expression, Types.DynamicRow);
-
-                var range = Expression.Convert(indexExp, Types.Range);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetRange, range, offsetVar, lengthVar);
-
-                var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
-                return new DynamicMetaObject(block, finalRestrictions);
-            }
-
-            if (indexType == Types.ColumnIdentifier)
-            {
-                var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.ColumnIdentifier);
-
-                var castToRow = Expression.Convert(expression, Types.DynamicRow);
-
-                var colId = Expression.Convert(indexExp, Types.ColumnIdentifier);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIdentifier, colId, testableDisposable, offsetVar, lengthVar);
-
-                var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
-                return new DynamicMetaObject(block, finalRestrictions);
-            }
-
-            // no binder
-            {
-                var msg = Expression.Constant($"Only string, int, Index, and Range indexers are supported.");
-                var invalidOpCall = Methods.Throw.InvalidOperationExceptionOfObject;
-                var call = Expression.Call(invalidOpCall, msg);
-
-                // we can cache this forever (for this type), since there's no scenario under which incorrect index types become correct
-                return new DynamicMetaObject(call, restrictions);
-            }
+            return DynamicExpressionHelper.BindGetIndexFor(restrictions, Expression, selfAsITestableDisposable, binder, indexes, null, null);
         }
 
         public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
@@ -188,63 +71,7 @@ namespace Cesil
             var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
             var selfAsITestable = Expression.Convert(Expression, Types.ITestableDisposable);
 
-            return BindGetMemberFor(restrictions, Expression, selfAsITestable, binder, null, null);
-        }
-
-        // todo: maybe move this to some common place?
-        internal static DynamicMetaObject BindGetMemberFor(
-            BindingRestrictions restrictions,
-            Expression expression, 
-            Expression iTestableDisposable,
-            GetMemberBinder binder, 
-            Expression? offset,
-            Expression? length
-        )
-        {
-            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
-            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
-
-            var assertNotDisposed = MakeAssertNotDisposedExpression(iTestableDisposable);
-
-            var name = Expression.Constant(binder.Name);
-            var castToRow = Expression.Convert(expression, Types.DynamicRow);
-            var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, name, iTestableDisposable, offsetVar, lengthVar);
-
-            var block = Expression.Block(assertNotDisposed, callOnSelf);
-
-            return new DynamicMetaObject(block, restrictions);
-        }
-
-        // todo: maybe move this somewhere else?
-        internal static BindingRestrictions MakeRestrictions(TypeInfo rowType, Expression expression, DynamicRowConverter? expected, Expression getDynamicRow, Expression getColumns, TypeInfo returnType)
-        {
-            var expectedConst = Expression.Constant(expected);
-            var get = GetRowConverter(getDynamicRow, getColumns, returnType);
-            var eq = Expression.Equal(expectedConst, get);
-
-            var sameConverterRestriction = BindingRestrictions.GetExpressionRestriction(eq);
-
-            var expressionIsRowRestriction = BindingRestrictions.GetTypeRestriction(expression, rowType);
-
-            var ret = expressionIsRowRestriction.Merge(sameConverterRestriction);
-
-            return ret;
-        }
-
-        private static Expression GetRowConverter(Expression getDynamicRow, Expression getColumns, TypeInfo forType)
-        {
-            var typeConst = Expression.Constant(forType);
-            var converter = Expression.Field(getDynamicRow, Fields.DynamicRow.Converter);
-            var rowNumber = Expression.Field(getDynamicRow, Fields.DynamicRow.RowNumber);
-            var context = Expression.Field(getDynamicRow, Fields.DynamicRow.Context);
-            var owner = Expression.Field(getDynamicRow, Fields.DynamicRow.Owner);
-            var options = Expression.Call(owner, Methods.IDynamicRowOwner.Options);
-
-            var getCtx = Expression.Call(Methods.ReadContext.ConvertingRow, options, rowNumber, context);
-
-            var dynamicRowConverter = Expression.Call(converter, Methods.ITypeDescriber.GetDynamicRowConverter, getCtx, getColumns, typeConst);
-
-            return dynamicRowConverter;
+            return DynamicExpressionHelper.BindGetMemberFor(restrictions, Expression, selfAsITestable, binder, null, null);
         }
 
         public override DynamicMetaObject BindConvert(ConvertBinder binder)
@@ -268,95 +95,14 @@ namespace Cesil
                 var selfAsRow = Expression.Convert(Expression, Types.DynamicRow);
                 var columns = Expression.Field(selfAsRow, Fields.DynamicRow.Columns);
 
-                restrictions = MakeRestrictions(Types.DynamicRow, Expression, converter, selfAsRow, columns, retType);
+                restrictions = DynamicExpressionHelper.MakeRestrictions(Types.DynamicRow, Expression, converter, selfAsRow, columns, retType);
             }
 
             var selfAsDynamicRow = Expression.Convert(Expression, Types.DynamicRow);
             var selfAsITestableDispoable = Expression.Convert(Expression, Types.ITestableDisposable);
-            var assertNotDisposed = MakeAssertNotDisposedExpression(selfAsITestableDispoable);
+            var assertNotDisposed = DynamicExpressionHelper.MakeAssertNotDisposedExpression(selfAsITestableDispoable);
 
-            return BindConvertFor(restrictions, selfAsDynamicRow, selfAsDynamicRow, assertNotDisposed, Row, retType, converter, null, null);
-        }
-
-        // todo: maybe move this to some common place?
-        internal static DynamicMetaObject BindConvertFor(
-            BindingRestrictions restrictions, 
-            Expression callSiteExpression,   // this needs to be either DynamicRow or DynamicRowRange typed
-            Expression dynamicRowExpression, // must be DynamicRow type
-            MethodCallExpression assertNotDisposed,
-            DynamicRow row, 
-            TypeInfo retType,
-            DynamicRowConverter? converter,
-            Expression? offset, 
-            Expression? length
-        )
-        {
-            // special case, converting to IDisposable will ALWAYS succeed
-            //   because every dynamic row supports disposal
-            if (retType == Types.IDisposable)
-            {
-                var cast = Expression.Convert(callSiteExpression, Types.IDisposable);
-
-                // intentionally NOT checking if the row is already disposed
-                return new DynamicMetaObject(cast, restrictions);
-            }
-
-            if (converter == null)
-            {
-                var invalidOpCall = Methods.Throw.InvalidOperationException.MakeGenericMethod(retType);
-                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"No row converter discovered for {retType}"));
-
-                return new DynamicMetaObject(throwMsg, restrictions);
-            }
-
-            if (!retType.IsAssignableFrom(converter.TargetType))
-            {
-                var invalidOpCall = Methods.Throw.InvalidOperationException.MakeGenericMethod(retType);
-                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"Row converter {converter} does not create a type assignable to {retType}, returns {converter.TargetType}"));
-
-                return new DynamicMetaObject(throwMsg, restrictions);
-            }
-
-            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
-            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
-
-            var statements = new List<Expression>();
-            statements.Add(assertNotDisposed);
-
-            var dynRowVar = Expressions.Variable_DynamicRow;
-            var assignDynRow = Expression.Assign(dynRowVar, dynamicRowExpression);
-            statements.Add(assignDynRow);
-
-            var outArg = Expression.Variable(retType);
-
-            var callGetContext = Expression.Call(dynRowVar, Methods.DynamicRow.GetReadContext, offsetVar, lengthVar);
-            var readCtxVar = Expressions.Variable_ReadContext;
-            var assignReadCtx = Expression.Assign(readCtxVar, callGetContext);
-            statements.Add(assignReadCtx);
-
-            var expressionVar = Expression.Variable(callSiteExpression.Type.GetTypeInfo());
-            var assignExpressionVar = Expression.Assign(expressionVar, callSiteExpression);
-            statements.Add(assignExpressionVar);
-            var convertExp = converter.MakeExpression(retType, expressionVar, readCtxVar, outArg);
-
-            var errorMsg = Expression.Constant($"{nameof(DynamicRowConverter)} ({converter}) could not convert dynamic row to {retType}");
-            var throwInvalidOp = Expression.Call(Methods.Throw.InvalidOperationExceptionOfObject, errorMsg);
-
-            var ifFalseThrow = Expression.IfThen(Expression.Not(convertExp), throwInvalidOp);
-            statements.Add(ifFalseThrow);
-            statements.Add(outArg);
-
-            var block = Expression.Block(new[] { outArg, dynRowVar, readCtxVar, expressionVar }, statements);
-
-            return new DynamicMetaObject(block, restrictions);
-        }
-
-        // todo: move somewhere else?
-        internal static MethodCallExpression MakeAssertNotDisposedExpression(Expression exp)
-        {
-            var call = Expression.Call(Methods.DisposableHelper.AssertNotDisposed, exp);
-
-            return call;
+            return DynamicExpressionHelper.BindConvertFor(restrictions, selfAsDynamicRow, selfAsDynamicRow, assertNotDisposed, Row, retType, converter, null, null);
         }
     }
 }

--- a/Cesil/Reader/Dynamic/DynamicRowMetaObject.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowMetaObject.cs
@@ -59,9 +59,18 @@ namespace Cesil
         }
 
         public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
-        {
-            var expressionIsDynamicRowRestriction = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
+        => BindGetIndexFor(BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow), Expression, binder, indexes, null, null);
 
+        // todo: maybe move this to some common place?
+        internal static DynamicMetaObject BindGetIndexFor(
+            BindingRestrictions restrictions,
+            Expression expression, 
+            GetIndexBinder _, 
+            DynamicMetaObject[] indexes, 
+            Expression? offset, 
+            Expression? length
+        )
+        {
             if (indexes.Length != 1)
             {
                 var msg = Expression.Constant($"Only single indexers are supported.");
@@ -69,8 +78,11 @@ namespace Cesil
                 var call = Expression.Call(invalidOpCall, msg);
 
                 // we can cache this forever (for this type), since there's no scenario under which indexes != 1 becomes correct
-                return new DynamicMetaObject(call, expressionIsDynamicRowRestriction);
+                return new DynamicMetaObject(call, restrictions);
             }
+
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
 
             var indexExp = indexes[0].Expression;
             var indexType = indexes[0].RuntimeType.GetTypeInfo();
@@ -79,16 +91,17 @@ namespace Cesil
             {
                 var indexExpressionIsIntRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Int);
 
-                var castToRow = Expression.Convert(Expression, Types.DynamicRow);
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
 
                 var index = Expression.Convert(indexExp, Types.Int);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetAt, index);
+                
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetAt, index, offsetVar, lengthVar);
 
-                var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+                var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
                 var block = Expression.Block(assertNotDisposed, callOnSelf);
 
-                var finalRestrictions = expressionIsDynamicRowRestriction.Merge(indexExpressionIsIntRestriction);
+                var finalRestrictions = restrictions.Merge(indexExpressionIsIntRestriction);
                 return new DynamicMetaObject(block, finalRestrictions);
             }
 
@@ -96,16 +109,16 @@ namespace Cesil
             {
                 var indexExpressionIsStringRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.String);
 
-                var castToRow = Expression.Convert(Expression, Types.DynamicRow);
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
 
                 var col = Expression.Convert(indexExp, Types.String);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, col);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, col, offsetVar, lengthVar);
 
-                var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+                var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
                 var block = Expression.Block(assertNotDisposed, callOnSelf);
 
-                var finalRestrictions = expressionIsDynamicRowRestriction.Merge(indexExpressionIsStringRestriction);
+                var finalRestrictions = restrictions.Merge(indexExpressionIsStringRestriction);
                 return new DynamicMetaObject(block, finalRestrictions);
             }
 
@@ -113,16 +126,16 @@ namespace Cesil
             {
                 var indexExpressionIsIndexRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Index);
 
-                var castToRow = Expression.Convert(Expression, Types.DynamicRow);
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
 
                 var col = Expression.Convert(indexExp, Types.Index);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIndex, col);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIndex, col, offsetVar, lengthVar);
 
-                var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+                var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
                 var block = Expression.Block(assertNotDisposed, callOnSelf);
 
-                var finalRestrictions = expressionIsDynamicRowRestriction.Merge(indexExpressionIsIndexRestriction);
+                var finalRestrictions = restrictions.Merge(indexExpressionIsIndexRestriction);
                 return new DynamicMetaObject(block, finalRestrictions);
             }
 
@@ -130,16 +143,16 @@ namespace Cesil
             {
                 var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.Range);
 
-                var castToRow = Expression.Convert(Expression, Types.DynamicRow);
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
 
                 var range = Expression.Convert(indexExp, Types.Range);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetRange, range);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetRange, range, offsetVar, lengthVar);
 
-                var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+                var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
                 var block = Expression.Block(assertNotDisposed, callOnSelf);
 
-                var finalRestrictions = expressionIsDynamicRowRestriction.Merge(indexExpressionIsRangeRestriction);
+                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
                 return new DynamicMetaObject(block, finalRestrictions);
             }
 
@@ -147,16 +160,16 @@ namespace Cesil
             {
                 var indexExpressionIsRangeRestriction = BindingRestrictions.GetTypeRestriction(indexExp, Types.ColumnIdentifier);
 
-                var castToRow = Expression.Convert(Expression, Types.DynamicRow);
+                var castToRow = Expression.Convert(expression, Types.DynamicRow);
 
                 var colId = Expression.Convert(indexExp, Types.ColumnIdentifier);
-                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIdentifier, colId);
+                var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByIdentifier, colId, offsetVar, lengthVar);
 
-                var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+                var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
                 var block = Expression.Block(assertNotDisposed, callOnSelf);
 
-                var finalRestrictions = expressionIsDynamicRowRestriction.Merge(indexExpressionIsRangeRestriction);
+                var finalRestrictions = restrictions.Merge(indexExpressionIsRangeRestriction);
                 return new DynamicMetaObject(block, finalRestrictions);
             }
 
@@ -167,54 +180,64 @@ namespace Cesil
                 var call = Expression.Call(invalidOpCall, msg);
 
                 // we can cache this forever (for this type), since there's no scenario under which incorrect index types become correct
-                return new DynamicMetaObject(call, expressionIsDynamicRowRestriction);
+                return new DynamicMetaObject(call, restrictions);
             }
         }
 
         public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        => BindGetMemberFor(BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow), Expression, binder, null, null);
+
+        // todo: maybe move this to some common place?
+        internal static DynamicMetaObject BindGetMemberFor(
+            BindingRestrictions restrictions,
+            Expression expression, 
+            GetMemberBinder binder, 
+            Expression? offset,
+            Expression? length
+        )
         {
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
 
             var name = Expression.Constant(binder.Name);
-            var castToRow = Expression.Convert(Expression, Types.DynamicRow);
-            var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, name);
+            var castToRow = Expression.Convert(expression, Types.DynamicRow);
+            var callOnSelf = Expression.Call(castToRow, Methods.DynamicRow.GetByName, name, offsetVar, lengthVar);
 
-            var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+            var assertNotDisposed = MakeAssertNotDisposedExpression(expression);
 
             var block = Expression.Block(assertNotDisposed, callOnSelf);
 
             return new DynamicMetaObject(block, restrictions);
         }
 
-        private BindingRestrictions MakeRestrictions(DynamicRowConverter? expected, TypeInfo returnType)
+        // todo: maybe move this somewhere else?
+        internal static BindingRestrictions MakeRestrictions(TypeInfo rowType, Expression expression, DynamicRowConverter? expected, Expression getDynamicRow, Expression getColumns, TypeInfo returnType)
         {
             var expectedConst = Expression.Constant(expected);
-            var get = GetRowConverter(returnType);
+            var get = GetRowConverter(getDynamicRow, getColumns, returnType);
             var eq = Expression.Equal(expectedConst, get);
 
             var sameConverterRestriction = BindingRestrictions.GetExpressionRestriction(eq);
 
-            var expressionIsRowRestriction = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
+            var expressionIsRowRestriction = BindingRestrictions.GetTypeRestriction(expression, rowType);
 
             var ret = expressionIsRowRestriction.Merge(sameConverterRestriction);
 
             return ret;
         }
 
-        private Expression GetRowConverter(TypeInfo forType)
+        private static Expression GetRowConverter(Expression getDynamicRow, Expression getColumns, TypeInfo forType)
         {
             var typeConst = Expression.Constant(forType);
-            var selfAsRow = Expression.Convert(Expression, Types.DynamicRow);
-            var converter = Expression.Field(selfAsRow, Fields.DynamicRow.Converter);
-            var rowNumber = Expression.Field(selfAsRow, Fields.DynamicRow.RowNumber);
-            var columns = Expression.Field(selfAsRow, Fields.DynamicRow.Columns);
-            var context = Expression.Field(selfAsRow, Fields.DynamicRow.Context);
-            var owner = Expression.Field(selfAsRow, Fields.DynamicRow.Owner);
+            var converter = Expression.Field(getDynamicRow, Fields.DynamicRow.Converter);
+            var rowNumber = Expression.Field(getDynamicRow, Fields.DynamicRow.RowNumber);
+            var context = Expression.Field(getDynamicRow, Fields.DynamicRow.Context);
+            var owner = Expression.Field(getDynamicRow, Fields.DynamicRow.Owner);
             var options = Expression.Call(owner, Methods.IDynamicRowOwner.Options);
 
             var getCtx = Expression.Call(Methods.ReadContext.ConvertingRow, options, rowNumber, context);
 
-            var dynamicRowConverter = Expression.Call(converter, Methods.ITypeDescriber.GetDynamicRowConverter, getCtx, columns, typeConst);
+            var dynamicRowConverter = Expression.Call(converter, Methods.ITypeDescriber.GetDynamicRowConverter, getCtx, getColumns, typeConst);
 
             return dynamicRowConverter;
         }
@@ -222,27 +245,53 @@ namespace Cesil
         public override DynamicMetaObject BindConvert(ConvertBinder binder)
         {
             var retType = binder.ReturnType.GetTypeInfo();
+            var isIDisposable = retType == Types.IDisposable;
 
+            DynamicRowConverter? converter;
+            BindingRestrictions restrictions;
+            
+            if (isIDisposable)
+            {
+                converter = null;
+                restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
+            }
+            else
+            {
+                var ctx = ReadContext.ConvertingRow(Row.Owner.Options, Row.RowNumber, Row.Context);
+                converter = Row.Converter.GetDynamicRowConverter(in ctx, Row.Columns, retType);
+
+                var selfAsRow = Expression.Convert(Expression, Types.DynamicRow);
+                var columns = Expression.Field(selfAsRow, Fields.DynamicRow.Columns);
+
+                restrictions = MakeRestrictions(Types.DynamicRow, Expression, converter, selfAsRow, columns, retType);
+            }
+
+            var selfAsDynamicRow = Expression.Convert(Expression, Types.DynamicRow);
+
+            return BindConvertFor(restrictions, selfAsDynamicRow, selfAsDynamicRow, Row, retType, converter, null, null);
+        }
+
+        // todo: maybe move this to some common place?
+        internal static DynamicMetaObject BindConvertFor(
+            BindingRestrictions restrictions, 
+            Expression callSiteExpression,   // this needs to be either DynamicRow or DynamicRowRange typed
+            Expression dynamicRowExpression, // must be DynamicRow type
+            DynamicRow row, 
+            TypeInfo retType,
+            DynamicRowConverter? converter,
+            Expression? offset, 
+            Expression? length
+        )
+        {
             // special case, converting to IDisposable will ALWAYS succeed
             //   because every dynamic row supports disposal
             if (retType == Types.IDisposable)
             {
-                var alwaysRestrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRow);
-                var cast = Expression.Convert(Expression, Types.IDisposable);
+                var cast = Expression.Convert(callSiteExpression, Types.IDisposable);
 
                 // intentionally NOT checking if the row is already disposed
-
-                return new DynamicMetaObject(cast, alwaysRestrictions);
+                return new DynamicMetaObject(cast, restrictions);
             }
-
-            var converterInterface = Row.Converter;
-            var index = Row.RowNumber;
-
-            var ctx = ReadContext.ConvertingRow(Row.Owner.Options, index, Row.Context);
-
-            var converter = converterInterface.GetDynamicRowConverter(in ctx, Row.Columns, retType);
-
-            var restrictions = MakeRestrictions(converter, retType);
 
             if (converter == null)
             {
@@ -252,41 +301,46 @@ namespace Cesil
                 return new DynamicMetaObject(throwMsg, restrictions);
             }
 
-            if (!binder.ReturnType.IsAssignableFrom(converter.TargetType))
+            if (!retType.IsAssignableFrom(converter.TargetType))
             {
                 var invalidOpCall = Methods.Throw.InvalidOperationException.MakeGenericMethod(retType);
-                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"Row converter {converter} does not create a type assignable to {binder.ReturnType}, returns {converter.TargetType}"));
+                var throwMsg = Expression.Call(invalidOpCall, Expression.Constant($"Row converter {converter} does not create a type assignable to {retType}, returns {converter.TargetType}"));
 
                 return new DynamicMetaObject(throwMsg, restrictions);
             }
 
+            var offsetVar = offset == null ? Expressions.Constant_NullInt : offset;
+            var lengthVar = length == null ? Expressions.Constant_NullInt : length;
+
             var statements = new List<Expression>();
 
-            var assertNotDisposed = MakeAssertNotDisposedExpression(Expression);
+            var assertNotDisposed = MakeAssertNotDisposedExpression(callSiteExpression);
             statements.Add(assertNotDisposed);
 
-            var selfAsRow = Expression.Convert(Expression, Types.DynamicRow);
             var dynRowVar = Expressions.Variable_DynamicRow;
-            var assignDynRow = Expression.Assign(dynRowVar, selfAsRow);
+            var assignDynRow = Expression.Assign(dynRowVar, dynamicRowExpression);
             statements.Add(assignDynRow);
 
-            var outArg = Expression.Variable(binder.ReturnType);
+            var outArg = Expression.Variable(retType);
 
-            var callGetContext = Expression.Call(dynRowVar, Methods.DynamicRow.GetReadContext);
+            var callGetContext = Expression.Call(dynRowVar, Methods.DynamicRow.GetReadContext, offsetVar, lengthVar);
             var readCtxVar = Expressions.Variable_ReadContext;
             var assignReadCtx = Expression.Assign(readCtxVar, callGetContext);
             statements.Add(assignReadCtx);
 
-            var convertExp = converter.MakeExpression(binder.ReturnType.GetTypeInfo(), dynRowVar, readCtxVar, outArg);
+            var expressionVar = Expression.Variable(callSiteExpression.Type.GetTypeInfo());
+            var assignExpressionVar = Expression.Assign(expressionVar, callSiteExpression);
+            statements.Add(assignExpressionVar);
+            var convertExp = converter.MakeExpression(retType, expressionVar, readCtxVar, outArg);
 
-            var errorMsg = Expression.Constant($"{nameof(DynamicRowConverter)} ({converter}) could not convert dynamic row to {binder.ReturnType}");
+            var errorMsg = Expression.Constant($"{nameof(DynamicRowConverter)} ({converter}) could not convert dynamic row to {retType}");
             var throwInvalidOp = Expression.Call(Methods.Throw.InvalidOperationExceptionOfObject, errorMsg);
 
             var ifFalseThrow = Expression.IfThen(Expression.Not(convertExp), throwInvalidOp);
             statements.Add(ifFalseThrow);
             statements.Add(outArg);
 
-            var block = Expression.Block(new[] { outArg, dynRowVar, readCtxVar }, statements);
+            var block = Expression.Block(new[] { outArg, dynRowVar, readCtxVar, expressionVar }, statements);
 
             return new DynamicMetaObject(block, restrictions);
         }

--- a/Cesil/Reader/Dynamic/DynamicRowRange.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowRange.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Immutable;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Cesil
+{
+    // todo: move this
+    internal sealed class DynamicRowRangeMetaObject : DynamicMetaObject
+    {
+        private readonly DynamicRowRange Range;
+
+        internal DynamicRowRangeMetaObject(DynamicRowRange range, Expression exp) : base(exp, BindingRestrictions.Empty, range)
+        {
+            Range = range;
+        }
+
+        private Expression AsDynamicRowRange()
+        => Expression.Convert(Expression, Types.DynamicRowRange);
+
+        private Expression GetOffset()
+        => Expression.Field(AsDynamicRowRange(), Fields.DynamicRowRange.Offset);
+
+        private Expression GetLength()
+        => Expression.Field(AsDynamicRowRange(), Fields.DynamicRowRange.Length);
+
+        private Expression GetParent()
+        => Expression.Field(AsDynamicRowRange(), Fields.DynamicRowRange.Parent);
+
+        // todo: BindInvokeMember
+
+        public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+
+            var dynamicRow = GetParent();
+            var offset = GetOffset();
+            var length = GetLength();
+
+            return DynamicRowMetaObject.BindGetIndexFor(restrictions, dynamicRow, binder, indexes, offset, length);
+        }
+
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+
+            var dynamicRow = GetParent();
+            var offset = GetOffset();
+            var length = GetLength();
+
+            return DynamicRowMetaObject.BindGetMemberFor(restrictions, dynamicRow, binder, offset, length);
+        }
+
+        public override DynamicMetaObject BindConvert(ConvertBinder binder)
+        {
+            var dynamicRow = GetParent();
+            var offset = GetOffset();
+            var length = GetLength();
+
+            var row = Range.Parent;
+
+            var retType = binder.ReturnType.GetTypeInfo();
+            var isIDisposable = retType == Types.IDisposable;
+
+            var selfAsDynamicRowRange = Expression.Convert(Expression, Types.DynamicRowRange);
+
+            DynamicRowConverter? converter;
+            BindingRestrictions restrictions;
+
+            if (isIDisposable)
+            {
+                converter = null;
+
+                restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+            }
+            else
+            {
+                var cols = Range.GetColumns();
+
+                var ctx = row.GetReadContext(Range.Offset, Range.Length);
+                converter = row.Converter.GetDynamicRowConverter(in ctx, cols, retType);
+
+                var callGetColumn = Expression.Call(selfAsDynamicRowRange, Methods.DynamicRowRange.GetColumns);
+                var ienumerableOfColumnIdentifiers = Types.IEnumerableOfT.MakeGenericType(Types.ColumnIdentifier).GetTypeInfo();
+                var asIEnumerable = Expression.Convert(callGetColumn, ienumerableOfColumnIdentifiers);
+
+                restrictions = DynamicRowMetaObject.MakeRestrictions(Types.DynamicRowRange, Expression, converter, dynamicRow, asIEnumerable, retType);
+            }
+
+            return DynamicRowMetaObject.BindConvertFor(restrictions, selfAsDynamicRowRange, dynamicRow, Range.Parent, retType, converter, offset, length);
+        }
+    }
+
+    internal sealed class DynamicRowRange : IDynamicMetaObjectProvider, ITestableDisposable
+    {
+        internal readonly DynamicRow Parent;
+
+        // keeping these nullable makes generating expressions easier
+        internal readonly int? Offset;
+        internal readonly int? Length;
+
+        public bool IsDisposed { get; private set; }
+
+        internal DynamicRowRange(DynamicRow parent, int offset, int length)
+        {
+            Parent = parent;
+            Offset = offset;
+            Length = length;
+        }
+
+        internal ImmutableArray<ColumnIdentifier> GetColumns()
+        {
+            // todo: remove allocations
+            var row = Parent;
+
+            var colsBuilder = ImmutableArray.CreateBuilder<ColumnIdentifier>();
+            var ix = 0;
+            foreach (var col in row.Columns)
+            {
+                if (ix < (Offset ?? 0))
+                {
+                    goto end;
+                }
+
+                if (colsBuilder.Count >= (Length ?? 0))
+                {
+                    break;
+                }
+
+                var n = col.HasName ? col.Name : "";
+
+                var newCol = ColumnIdentifier.CreateInner(colsBuilder.Count, n, null);
+
+                colsBuilder.Add(newCol);
+
+end:
+                ix++;
+            }
+
+            return colsBuilder.ToImmutable();
+        }
+
+        public DynamicMetaObject GetMetaObject(Expression parameter)
+        => new DynamicRowRangeMetaObject(this, parameter);
+
+        public void Dispose()
+        {
+            if (!IsDisposed)
+            {
+                IsDisposed = true;
+                // todo: something?
+            }
+        }
+
+        public override string ToString()
+        => $"{nameof(DynamicRowRange)} with Offset={Offset}, Length={Length}, Parent={Parent}";
+    }
+}

--- a/Cesil/Reader/Dynamic/DynamicRowRangeMetaObject.cs
+++ b/Cesil/Reader/Dynamic/DynamicRowRangeMetaObject.cs
@@ -1,0 +1,126 @@
+﻿using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Cesil
+{
+    internal sealed class DynamicRowRangeMetaObject : DynamicMetaObject
+    {
+        private readonly DynamicRowRange Range;
+
+        internal DynamicRowRangeMetaObject(DynamicRowRange range, Expression exp) : base(exp, BindingRestrictions.Empty, range)
+        {
+            Range = range;
+        }
+
+        private void GetCommonExpressions(out Expression asDynamicRowRange, out Expression offset, out Expression length, out Expression parent)
+        {
+            asDynamicRowRange = Expression.Convert(Expression, Types.DynamicRowRange);
+            offset = Expression.Field(asDynamicRowRange, Fields.DynamicRowRange.Offset);
+            length = Expression.Field(asDynamicRowRange, Fields.DynamicRowRange.Length);
+            parent = Expression.Field(asDynamicRowRange, Fields.DynamicRowRange.Parent);
+        }
+
+        public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
+        {
+            var expressionIsDynamicRowRangeRestriction = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+
+            // only supported operation is .Dispose()
+            if (binder.Name == nameof(DynamicRowRange.Dispose) && args.Length == 0)
+            {
+                var castToRow = Expression.Convert(Expression, Types.DynamicRowRange);
+                var callDispose = Expression.Call(castToRow, Methods.DynamicRowRange.Dispose);
+
+                Expression final;
+
+                if (binder.ReturnType == Types.Void)
+                {
+                    final = callDispose;
+                }
+                else
+                {
+                    if (binder.ReturnType == Types.Object)
+                    {
+                        final = Expression.Block(callDispose, Expressions.Constant_Null);
+                    }
+                    else
+                    {
+                        final = Expression.Block(callDispose, Expression.Default(binder.ReturnType));
+                    }
+                }
+
+                // we can cache this forever (for this type), doesn't vary by anything else
+                return new DynamicMetaObject(final, expressionIsDynamicRowRangeRestriction);
+            }
+
+            var msg = Expression.Constant($"Only the Dispose() method is supported.");
+            var invalidOpCall = Methods.Throw.InvalidOperationExceptionOfObject;
+            var call = Expression.Call(invalidOpCall, msg);
+
+            // we can cache this forever (for this type), since there's no scenario under which a non-Dispose call
+            //    becomes legal
+            return new DynamicMetaObject(call, expressionIsDynamicRowRangeRestriction);
+        }
+
+        public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+
+            GetCommonExpressions(out var selfAsDynamicRowRange, out var offset, out var length, out var dynamicRow);
+
+            var selfAsITestableDisposable = Expression.Convert(selfAsDynamicRowRange, Types.ITestableDisposable);
+
+            return DynamicExpressionHelper.BindGetIndexFor(restrictions, dynamicRow, selfAsITestableDisposable, binder, indexes, offset, length);
+        }
+
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+
+            GetCommonExpressions(out var selfAsDynamicRowRange, out var offset, out var length, out var dynamicRow);
+
+            var selfAsITestableDisposable = Expression.Convert(selfAsDynamicRowRange, Types.ITestableDisposable);
+
+            return DynamicExpressionHelper.BindGetMemberFor(restrictions, dynamicRow, selfAsITestableDisposable, binder, offset, length);
+        }
+
+        public override DynamicMetaObject BindConvert(ConvertBinder binder)
+        {
+
+            GetCommonExpressions(out var selfAsDynamicRowRange, out var offset, out var length, out var dynamicRow);
+
+            var row = Range.Parent;
+
+            var retType = binder.ReturnType.GetTypeInfo();
+            var isIDisposable = retType == Types.IDisposable;
+
+            DynamicRowConverter? converter;
+            BindingRestrictions restrictions;
+
+            if (isIDisposable)
+            {
+                converter = null;
+
+                restrictions = BindingRestrictions.GetTypeRestriction(Expression, Types.DynamicRowRange);
+            }
+            else
+            {
+                var cols = Range.Columns;
+
+                var ctx = row.GetReadContext(Range.Offset, Range.Length);
+                converter = row.Converter.GetDynamicRowConverter(in ctx, cols, retType);
+
+                var callGetColumn = Expression.Field(selfAsDynamicRowRange, Fields.DynamicRowRange.Columns);
+                var ienumerableOfColumnIdentifiers = Types.IEnumerableOfT.MakeGenericType(Types.ColumnIdentifier).GetTypeInfo();
+                var asIEnumerable = Expression.Convert(callGetColumn, ienumerableOfColumnIdentifiers);
+
+                restrictions = DynamicExpressionHelper.MakeRestrictions(Types.DynamicRowRange, Expression, converter, dynamicRow, asIEnumerable, retType);
+            }
+
+            var selfAsITestableDisposable = Expression.Convert(Expression, Types.ITestableDisposable);
+            var assertNotDisposed = DynamicExpressionHelper.MakeAssertNotDisposedExpression(selfAsITestableDisposable);
+
+            return DynamicExpressionHelper.BindConvertFor(restrictions, selfAsDynamicRowRange, dynamicRow, assertNotDisposed, Range.Parent, retType, converter, offset, length);
+        }
+    }
+}

--- a/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
+++ b/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
@@ -14,13 +14,13 @@ namespace Cesil
 
         internal PassthroughRowEnumerable(object row)
         {
-            if(row is DynamicRow dynRow)
+            if (row is DynamicRow dynRow)
             {
                 Row = dynRow;
                 DependsOn = dynRow;
                 Offset = Length = null;
             }
-            else if(row is DynamicRowRange dynRowRange)
+            else if (row is DynamicRowRange dynRowRange)
             {
                 Row = dynRowRange.Parent;
                 DependsOn = dynRowRange;

--- a/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
+++ b/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Cesil
 {
@@ -7,10 +8,28 @@ namespace Cesil
     {
         private readonly uint Generation;
         private readonly DynamicRow Row;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         internal PassthroughRowEnumerable(object row)
         {
-            Row = (DynamicRow)row;
+            if(row is DynamicRow dynRow)
+            {
+                Row = dynRow;
+                Offset = Length = null;
+            }
+            else if(row is DynamicRowRange dynRowRange)
+            {
+                Row = dynRowRange.Parent;
+                Offset = dynRowRange.Offset;
+                Length = dynRowRange.Length;
+            }
+            else
+            {
+                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+                return;
+            }
+
             Generation = Row.Generation;
         }
 
@@ -18,7 +37,7 @@ namespace Cesil
         {
             Row.AssertGenerationMatch(Generation);
 
-            return new PassthroughRowEnumerator(Row);
+            return new PassthroughRowEnumerator(Row, Offset, Length);
         }
 
         [ExcludeFromCoverage("Trivial, and covered by IEnumerable<T>.GetEnumerator()")]

--- a/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
+++ b/Cesil/Reader/Dynamic/PassthroughRowEnumerable.cs
@@ -8,6 +8,7 @@ namespace Cesil
     {
         private readonly uint Generation;
         private readonly DynamicRow Row;
+        private readonly ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
@@ -16,17 +17,19 @@ namespace Cesil
             if(row is DynamicRow dynRow)
             {
                 Row = dynRow;
+                DependsOn = dynRow;
                 Offset = Length = null;
             }
             else if(row is DynamicRowRange dynRowRange)
             {
                 Row = dynRowRange.Parent;
+                DependsOn = dynRowRange;
                 Offset = dynRowRange.Offset;
                 Length = dynRowRange.Length;
             }
             else
             {
-                Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
+                DependsOn = Row = Throw.ImpossibleException<DynamicRow>($"Unexpected dynamic row type ({row.GetType().GetTypeInfo()})");
                 return;
             }
 
@@ -37,7 +40,7 @@ namespace Cesil
         {
             Row.AssertGenerationMatch(Generation);
 
-            return new PassthroughRowEnumerator(Row, Offset, Length);
+            return new PassthroughRowEnumerator(Row, DependsOn, Offset, Length);
         }
 
         [ExcludeFromCoverage("Trivial, and covered by IEnumerable<T>.GetEnumerator()")]

--- a/Cesil/Reader/Dynamic/PassthroughRowEnumerator.cs
+++ b/Cesil/Reader/Dynamic/PassthroughRowEnumerator.cs
@@ -10,6 +10,7 @@ namespace Cesil
         // this checks that reusing the underlying DynamicRow will
         //   cause a generation check failure
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        ITestableDisposable DependsOn;
         private readonly int? Offset;
         private readonly int? Length;
 
@@ -28,10 +29,11 @@ namespace Cesil
         [ExcludeFromCoverage("Trivial, and covered by IEnumerator<T>.Current")]
         object? IEnumerator.Current => Current;
 
-        internal PassthroughRowEnumerator(DynamicRow row, int? offset, int? length)
+        internal PassthroughRowEnumerator(DynamicRow row, ITestableDisposable dependsOn, int? offset, int? length)
         {
             _Current = null;
             Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            DependsOn = dependsOn;
             Offset = offset;
             Length = length;
         }
@@ -50,7 +52,7 @@ namespace Cesil
 
             var trueIndex = col.Index + (Offset ?? 0);
 
-            var val = Enumerator.Row.GetCellAt(trueIndex);
+            var val = Enumerator.Row.GetCellAt(DependsOn, trueIndex);
             if (val == null)
             {
                 _Current = null;

--- a/Cesil/Reader/Dynamic/PassthroughRowEnumerator.cs
+++ b/Cesil/Reader/Dynamic/PassthroughRowEnumerator.cs
@@ -10,6 +10,8 @@ namespace Cesil
         // this checks that reusing the underlying DynamicRow will
         //   cause a generation check failure
         private readonly DynamicRow.DynamicColumnEnumerator Enumerator;
+        private readonly int? Offset;
+        private readonly int? Length;
 
         public bool IsDisposed => Enumerator.IsDisposed;
 
@@ -26,10 +28,12 @@ namespace Cesil
         [ExcludeFromCoverage("Trivial, and covered by IEnumerator<T>.Current")]
         object? IEnumerator.Current => Current;
 
-        internal PassthroughRowEnumerator(DynamicRow row)
+        internal PassthroughRowEnumerator(DynamicRow row, int? offset, int? length)
         {
             _Current = null;
-            Enumerator = new DynamicRow.DynamicColumnEnumerator(row);
+            Enumerator = new DynamicRow.DynamicColumnEnumerator(row, offset, length);
+            Offset = offset;
+            Length = length;
         }
 
         public bool MoveNext()
@@ -44,7 +48,9 @@ namespace Cesil
 
             var col = Enumerator.Current;
 
-            var val = Enumerator.Row.GetCellAt(col.Index);
+            var trueIndex = col.Index + (Offset ?? 0);
+
+            var val = Enumerator.Row.GetCellAt(trueIndex);
             if (val == null)
             {
                 _Current = null;

--- a/Cesil/Reader/RowConstructors/DynamicRowConstructor.cs
+++ b/Cesil/Reader/RowConstructors/DynamicRowConstructor.cs
@@ -32,13 +32,22 @@ namespace Cesil
         {
             if (checkPrealloc && prealloc is DynamicRow asObj)
             {
-                PreAlloced = asObj;
+                // dispose!  we're taking it now
                 asObj.Dispose();
+
+                // check if the _data_ is disposed
+                //   this thing could be semantically disposed by the data actually could be in use
+                //   which would be _bad_
+                if (asObj.OutstandingUsesOfData == 0)
+                {
+                    PreAlloced = asObj;
+
+                    return true;
+                }
             }
-            else
-            {
-                prealloc = PreAlloced = new DynamicRow();
-            }
+
+            // we don't have a usable row, make a new one
+            prealloc = PreAlloced = new DynamicRow();
 
             return true;
         }

--- a/Cesil/TypeDescriber/DefaultTypeDescriber.cs
+++ b/Cesil/TypeDescriber/DefaultTypeDescriber.cs
@@ -871,6 +871,8 @@ endLoop:
                 return nextRetIx;
             }
 
+            // todo: add DynamicRowRange
+
             // special case the most convenient dynamic type
             if (row is ExpandoObject asExpando)
             {

--- a/Cesil/TypeDescriber/TupleDynamicParsers.cs
+++ b/Cesil/TypeDescriber/TupleDynamicParsers.cs
@@ -59,33 +59,33 @@ namespace Cesil
 
         private static object GetTupleForRow(DynamicRow row, TypeInfo[] colTypes)
         {
-            var data = MakeArrayOfObjects(row, null, null, colTypes);
+            var data = MakeArrayOfObjects(row, row, null, null, colTypes);
 
             return ConvertToTuple(colTypes, data, 0, Types.Tuple_Array);
         }
 
         private static object GetTupleForRange(DynamicRowRange row, TypeInfo[] colTypes)
         {
-            var data = MakeArrayOfObjects(row.Parent, row.Offset, row.Length, colTypes);
+            var data = MakeArrayOfObjects(row.Parent, row, row.Offset, row.Length, colTypes);
 
             return ConvertToTuple(colTypes, data, 0, Types.Tuple_Array);
         }
 
         private static object GetValueTupleForRow(DynamicRow row, TypeInfo[] colTypes)
         {
-            var data = MakeArrayOfObjects(row, null, null, colTypes);
+            var data = MakeArrayOfObjects(row, row, null, null, colTypes);
 
             return ConvertToTuple(colTypes, data, 0, Types.ValueTuple_Array);
         }
 
         private static object GetValueTupleForRange(DynamicRowRange row, TypeInfo[] colTypes)
         {
-            var data = MakeArrayOfObjects(row.Parent, row.Offset, row.Length, colTypes);
+            var data = MakeArrayOfObjects(row.Parent, row, row.Offset, row.Length, colTypes);
 
             return ConvertToTuple(colTypes, data, 0, Types.ValueTuple_Array);
         }
 
-        private static object?[] MakeArrayOfObjects(DynamicRow row, int? offset, int? length, TypeInfo[] colTypes)
+        private static object?[] MakeArrayOfObjects(DynamicRow row, ITestableDisposable dependsOn, int? offset, int? length, TypeInfo[] colTypes)
         {
             var ret = new object?[length ?? colTypes.Length];
 
@@ -103,7 +103,7 @@ namespace Cesil
                     goto end;
                 }
 
-                var cell = row.GetCellAt(i);
+                var cell = row.GetCellAt(dependsOn, i);
                 if (cell == null)
                 {
                     return Throw.InvalidOperationException<object[]>("Unexpected null value in dynamic row cell");

--- a/Cesil/TypeDescriber/Wrappers/DynamicRowConverter.cs
+++ b/Cesil/TypeDescriber/Wrappers/DynamicRowConverter.cs
@@ -197,6 +197,8 @@ namespace Cesil
                                 return Throw.ImpossibleException<Expression>($"Attempted to convert unexpected dynamic type ({rowVarType})");
                             }
 
+                            var iTestableDisposable = Expression.Convert(rowVar, Types.ITestableDisposable);
+
                             var ps = new List<Expression>();
                             for (var pIx = 0; pIx < colsForPs.Length; pIx++)
                             {
@@ -204,7 +206,7 @@ namespace Cesil
                                 var pType = paramTypes[pIx];
                                 var getter = Methods.DynamicRow.GetAtTyped.MakeGenericMethod(pType);
 
-                                var call = Expression.Call(dynamicRowVar, getter, Expression.Constant(colIx), offsetExp, lengthExp);
+                                var call = Expression.Call(dynamicRowVar, getter, Expression.Constant(colIx), iTestableDisposable, offsetExp, lengthExp);
 
                                 ps.Add(call);
                             }
@@ -262,6 +264,8 @@ namespace Cesil
                                 return Throw.ImpossibleException<Expression>($"Attempted to convert unexpected dynamic type ({rowVarType})");
                             }
 
+                            var iTestableDisposable = Expression.Convert(rowVar, Types.ITestableDisposable);
+
                             for (var i = 0; i < setters.Length; i++)
                             {
                                 var setter = setters[i];
@@ -269,7 +273,7 @@ namespace Cesil
 
                                 var getValueMtd = Methods.DynamicRow.GetAtTyped.MakeGenericMethod(setter.Takes);
 
-                                var getValueCall = Expression.Call(dynamicRowVar, getValueMtd, Expression.Constant(setterColumn), offsetExp, lengthExp);
+                                var getValueCall = Expression.Call(dynamicRowVar, getValueMtd, Expression.Constant(setterColumn), iTestableDisposable, offsetExp, lengthExp);
                                 var valueVar = Expression.Parameter(setter.Takes);
                                 var assignValueVar = Expression.Assign(valueVar, getValueCall);
                                 locals.Add(valueVar);


### PR DESCRIPTION
Introduces a new DynamicRowRange type that is used when a range is taken of a DynamicRow.  This removes the "copy the whole subset"-behavior from taking ranges of DynamicRows, fixing #9.

DynamicRowRange essentially stores a reference to a DynamicRow, and will keep it alive until all ranges and the row are disposed.  This makes taking a range of a DynamicRow O(1), instead of O(n) (relative to the number of cells taken from the row).

### Internal changes

 - Introduces DynamicRowRange and it's associated dynamic object infrastructure
 - A lot of existing dynamic infrastructure grows Offset and Length fields, so they can be used with either type
