### PR TITLE
Test weird reflection cases

### DIFF
--- a/Cesil.Tests/UtilsTests.cs
+++ b/Cesil.Tests/UtilsTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace Cesil.Tests
@@ -353,6 +354,94 @@ namespace Cesil.Tests
             // generic tuple types
             Assert.True(typeof(Tuple<,,,,,,,>).GetTypeInfo().IsBigTuple());
             Assert.True(typeof(ValueTuple<,,,,,,,>).GetTypeInfo().IsBigValueTuple());
+        }
+
+        [Fact]
+        public void WeirdReflectionCases()
+        {
+            // fields with no declaring type
+            {
+                var name = $"{nameof(Cesil)}.{nameof(UtilsTests)}.{nameof(WeirdReflectionCases)}.Fields";
+                var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+                var modBuilder = asmBuilder.DefineDynamicModule("Module");
+                var fieldBuilder = modBuilder.DefineInitializedData("WeirdField", new byte[4] { 1, 2, 3, 4 }, FieldAttributes.Static | FieldAttributes.Public);
+                modBuilder.CreateGlobalFunctions();
+
+                var field = modBuilder.GetField(fieldBuilder.Name, BindingFlags.Static | BindingFlags.Public);
+
+                var exc = Assert.Throws<InvalidOperationException>(() => field.DeclaringTypeNonNull());
+                Assert.StartsWith("Could not find declaring type for ", exc.Message);
+            }
+
+            // method with no declaring type
+            {
+                var name = $"{nameof(Cesil)}.{nameof(UtilsTests)}.{nameof(WeirdReflectionCases)}.Methods";
+                var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+                var modBuilder = asmBuilder.DefineDynamicModule("Module");
+                var mtdBuilder = modBuilder.DefineGlobalMethod("WeirdMethod", MethodAttributes.Static | MethodAttributes.Public, null, null);
+                var ilGen = mtdBuilder.GetILGenerator();
+                ilGen.Emit(OpCodes.Ret);
+
+                modBuilder.CreateGlobalFunctions();
+
+                var mtd = modBuilder.GetMethod(mtdBuilder.Name);
+
+                var exc = Assert.Throws<InvalidOperationException>(() => mtd.DeclaringTypeNonNull());
+                Assert.StartsWith("Could not find declaring type for ", exc.Message);
+            }
+
+            // constructor with no declaring type
+            {
+                var name = $"{nameof(Cesil)}.{nameof(UtilsTests)}.{nameof(WeirdReflectionCases)}.Constructors";
+                var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+                var modBuilder = asmBuilder.DefineDynamicModule("Module");
+
+                var globalTypeBuilder = GetModuleTypeBuilder(modBuilder);
+
+                // now we can make a static constructor on this stupid fake type
+                var consBuilder = globalTypeBuilder.DefineConstructor(MethodAttributes.Static | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName, CallingConventions.Standard, null);
+                var ilGenerator = consBuilder.GetILGenerator();
+                ilGenerator.Emit(OpCodes.Ret);
+
+                // actually emit things...
+                modBuilder.CreateGlobalFunctions();
+
+                var cons = Assert.IsAssignableFrom<ConstructorInfo>(consBuilder);
+
+                var exc = Assert.Throws<InvalidOperationException>(() => cons.DeclaringTypeNonNull());
+                Assert.StartsWith("Could not find declaring type for ", exc.Message);
+            }
+
+            // TypeBuilder makes a type but returns null
+            {
+                var name = $"{nameof(Cesil)}.{nameof(UtilsTests)}.{nameof(WeirdReflectionCases)}.TypeBuilder";
+                var asmBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+                var modBuilder = asmBuilder.DefineDynamicModule("Module");
+
+                var globalTypeBuilder = GetModuleTypeBuilder(modBuilder);
+
+                var exc = Assert.Throws<InvalidOperationException>(() => globalTypeBuilder.CreateTypeNonNull());
+                Assert.Equal("Created type was null", exc.Message);
+            }
+
+            // get the TypeBuilder for the hidden <Module> type
+            static TypeBuilder GetModuleTypeBuilder(ModuleBuilder modBuilder)
+            {
+                // blruuuuuugh, getting this out properly is a huge pain... so just reflect it out
+                var moduleDataField = modBuilder.GetType().GetField("_moduleData", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.NotNull(moduleDataField);
+
+                var moduleData = moduleDataField.GetValue(modBuilder);
+
+                var globalTypeBuilderField = moduleData.GetType().GetField("_globalTypeBuilder", BindingFlags.Public | BindingFlags.Instance);
+                Assert.NotNull(globalTypeBuilderField);
+
+                var globalTypeBuilderObj = globalTypeBuilderField.GetValue(moduleData);
+
+                var globalTypeBuilder = Assert.IsAssignableFrom<TypeBuilder>(globalTypeBuilderObj);
+
+                return globalTypeBuilder;
+            }
         }
 
         [Fact]

--- a/Cesil/Common/ReflectionExtensionMethods.cs
+++ b/Cesil/Common/ReflectionExtensionMethods.cs
@@ -329,8 +329,9 @@ namespace Cesil
         {
             var declNull = cons.DeclaringType;
 
-            // technically possible, but fantastically hard to do in C#
-            // todo: find a way to test this? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/3)
+            // this is basically impossible, BUT if something has caused a constructor
+            //   to be defined in the fake-ish <Module> type in an assembly it will
+            //   happen
             if (declNull == null)
             {
                 return Throw.InvalidOperationException<TypeInfo>($"Could not find declaring type for {cons}");
@@ -343,8 +344,8 @@ namespace Cesil
         {
             var declNull = mtd.DeclaringType;
 
-            // technically possible, but fantastically hard to do in C#
-            // todo: find a way to test this? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/3)
+            // this happens if the method is declared as part of a _module_ but not a type
+            //   which is weird, but legal, so check for it
             if (declNull == null)
             {
                 return Throw.InvalidOperationException<TypeInfo>($"Could not find declaring type for {mtd}");
@@ -357,8 +358,8 @@ namespace Cesil
         {
             var declNull = field.DeclaringType;
 
-            // technically possible, but fantastically hard to do in C#
-            // todo: find a way to test this? (tracking issue: https://github.com/kevin-montrose/Cesil/issues/3)
+            // this happens if the field is declared as part of a _module_
+            //   which is weird, but legal, so check for it
             if (declNull == null)
             {
                 return Throw.InvalidOperationException<TypeInfo>($"Could not find declaring type for {field}");
@@ -441,8 +442,8 @@ namespace Cesil
         {
             var type = builder.CreateTypeInfo();
 
-            // is this ever really possible?
-            // todo: find a way to test (tracking issue: https://github.com/kevin-montrose/Cesil/issues/3)
+            // this is possible if the TypeBuilder is making the <Module> type in the assembly
+            //   which is craaaaazy unlikely but technically possible
             if (type == null)
             {
                 return Throw.InvalidOperationException<TypeInfo>($"Created type was null");


### PR DESCRIPTION
All the weird untested cases revolve around module methods, fields, and the `<Module>` type.

Fantastically unlikely this will ever matter for client code, but the cases _are_ testable - so now they are tested.  Closes #3 .

### Visible changes

 - None